### PR TITLE
CHORE: Organization change from GuideSmiths to OneBeyond

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 [![Nuget version](https://img.shields.io/nuget/v/Monaco.Template.Solution?style=plastic)](https://www.nuget.org/packages/Monaco.Template.Solution)
 [![Nuget downloads](https://img.shields.io/nuget/dt/Monaco.Template.Solution?style=plastic)](https://www.nuget.org/packages/Monaco.Template.Solution)
-[![License](https://img.shields.io/github/license/GuideSmiths/monaco?style=plastic)](LICENSE.TXT)
-[![Release to NuGet](https://github.com/guidesmiths/monaco/actions/workflows/release.yml/badge.svg)](https://github.com/guidesmiths/monaco/actions/workflows/release.yml)
+[![License](https://img.shields.io/github/license/OneBeyond/monaco?style=plastic)](LICENSE.TXT)
+[![Release to NuGet](https://github.com/onebeyond/monaco/actions/workflows/release.yml/badge.svg)](https://github.com/onebeyond/monaco/actions/workflows/release.yml)
 
 # Introduction 
 Monaco is a .NET solution template that provides the scaffolding for a .NET solution based on the [Vertical Slices Architecture](https://www.youtube.com/watch?v=SUiWfhAhgQw).
@@ -31,7 +31,7 @@ It also provides some basic business components as example of real life implemen
 
 `dotnet new monaco-solution -n MyFirstSolution`
 
-This will create a folder named `MyFirstSolution`, which will contain a structure of directories prefixed with the name as part of the namespace declaration. The resulting solution will include the default layout and all the files required to run the application (more info about this [here](https://github.com/guidesmiths/monaco/wiki/Solution-projects-structure))
+This will create a folder named `MyFirstSolution`, which will contain a structure of directories prefixed with the name as part of the namespace declaration. The resulting solution will include the default layout and all the files required to run the application (more info about this [here](https://github.com/onebeyond/onebeyond/wiki/Solution-projects-structure))
 
 From there, is enough to configure `appsettings.json` with the required settings and run the app.
 
@@ -39,11 +39,11 @@ From there, is enough to configure `appsettings.json` with the required settings
 
 `dotnet new monaco-solution --help`
 
-(For more information about Monaco options please refer [here](https://github.com/guidesmiths/monaco/wiki/Template-options))
+(For more information about Monaco options please refer [here](https://github.com/onebeyond/monaco/wiki/Template-options))
 
 # Documentation
 
-For more detailed documentation, please refer to our [Wiki](https://github.com/guidesmiths/monaco/wiki)
+For more detailed documentation, please refer to our [Wiki](https://github.com/onebeyond/monaco/wiki)
 
 # Visual Studio support
 

--- a/src/Content/Monaco.Template.Common.Api.Application/Monaco.Template.Common.Api.Application.csproj
+++ b/src/Content/Monaco.Template.Common.Api.Application/Monaco.Template.Common.Api.Application.csproj
@@ -11,8 +11,8 @@
     <Authors>One Beyond</Authors>
     <Company>One Beyond</Company>
     <Copyright>One Beyond</Copyright>
-    <PackageProjectUrl>https://github.com/guidesmiths/monaco</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/guidesmiths/monaco.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/onebeyond/monaco</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/onebeyond/monaco.git</RepositoryUrl>
     <Description>Library with extensions for adapting MediatR responses for a REST API.</Description>
     <RepositoryType>Git</RepositoryType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Content/Monaco.Template.Common.Api/Monaco.Template.Common.Api.csproj
+++ b/src/Content/Monaco.Template.Common.Api/Monaco.Template.Common.Api.csproj
@@ -11,8 +11,8 @@
     <Authors>One Beyond</Authors>
     <Company>One Beyond</Company>
     <Copyright>One Beyond</Copyright>
-    <PackageProjectUrl>https://github.com/guidesmiths/monaco</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/guidesmiths/monaco.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/onebeyond/monaco</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/onebeyond/monaco.git</RepositoryUrl>
     <Description>Library with common classes and helpers for the REST API.</Description>
     <RepositoryType>Git</RepositoryType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Content/Monaco.Template.Common.Application/Monaco.Template.Common.Application.csproj
+++ b/src/Content/Monaco.Template.Common.Application/Monaco.Template.Common.Application.csproj
@@ -11,8 +11,8 @@
 	<Authors>One Beyond</Authors>
 	<Company>One Beyond</Company>
 	<Copyright>One Beyond</Copyright>
-	<PackageProjectUrl>https://github.com/guidesmiths/monaco</PackageProjectUrl>
-	<RepositoryUrl>https://github.com/guidesmiths/monaco.git</RepositoryUrl>
+	<PackageProjectUrl>https://github.com/onebeyond/monaco</PackageProjectUrl>
+	<RepositoryUrl>https://github.com/onebeyond/monaco.git</RepositoryUrl>
 	<Description>Library with base classes and helpers for the Application library.</Description>
 	<RepositoryType>Git</RepositoryType>
 	<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Content/Monaco.Template.Common.BlobStorage/Monaco.Template.Common.BlobStorage.csproj
+++ b/src/Content/Monaco.Template.Common.BlobStorage/Monaco.Template.Common.BlobStorage.csproj
@@ -11,8 +11,8 @@
 	<Authors>One Beyond</Authors>
 	<Company>One Beyond</Company>
 	<Copyright>One Beyond</Copyright>
-	<PackageProjectUrl>https://github.com/guidesmiths/monaco</PackageProjectUrl>
-	<RepositoryUrl>https://github.com/guidesmiths/monaco.git</RepositoryUrl>
+	<PackageProjectUrl>https://github.com/onebeyond/monaco</PackageProjectUrl>
+	<RepositoryUrl>https://github.com/onebeyond/monaco.git</RepositoryUrl>
 	<Description>Monaco's service implementation for handling files on Azure BlobStorage.</Description>
 	<RepositoryType>Git</RepositoryType>
 	<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Content/Monaco.Template.Common.Domain/Monaco.Template.Common.Domain.csproj
+++ b/src/Content/Monaco.Template.Common.Domain/Monaco.Template.Common.Domain.csproj
@@ -11,8 +11,8 @@
     <Authors>One Beyond</Authors>
     <Company>One Beyond</Company>
     <Copyright>One Beyond</Copyright>
-    <PackageProjectUrl>https://github.com/guidesmiths/monaco</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/guidesmiths/monaco.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/onebeyond/monaco</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/onebeyond/monaco.git</RepositoryUrl>
     <Description>Library with classes and contracts for the Domain library.</Description>
     <RepositoryType>Git</RepositoryType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Content/Monaco.Template.Common.Infrastructure/Monaco.Template.Common.Infrastructure.csproj
+++ b/src/Content/Monaco.Template.Common.Infrastructure/Monaco.Template.Common.Infrastructure.csproj
@@ -11,8 +11,8 @@
     <Authors>One Beyond</Authors>
     <Company>One Beyond</Company>
     <Copyright>One Beyond</Copyright>
-    <PackageProjectUrl>https://github.com/guidesmiths/monaco</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/guidesmiths/monaco.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/onebeyond/monaco</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/onebeyond/monaco.git</RepositoryUrl>
     <Description>Library with base classes and helpers for the Application's Infrastructure library.</Description>
     <RepositoryType>Git</RepositoryType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Content/Monaco.Template.Common.Messaging.Messages/Monaco.Template.Common.Messaging.Messages.csproj
+++ b/src/Content/Monaco.Template.Common.Messaging.Messages/Monaco.Template.Common.Messaging.Messages.csproj
@@ -11,8 +11,8 @@
     <Authors>One Beyond</Authors>
     <Company>One Beyond</Company>
     <Copyright>One Beyond</Copyright>
-    <PackageProjectUrl>https://github.com/guidesmiths/monaco</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/guidesmiths/monaco.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/onebeyond/monaco</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/onebeyond/monaco.git</RepositoryUrl>
     <Description>Library with messages for MassTransit messaging.</Description>
     <RepositoryType>Git</RepositoryType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Content/Monaco.Template.Common.Serilog/Monaco.Template.Common.Serilog.csproj
+++ b/src/Content/Monaco.Template.Common.Serilog/Monaco.Template.Common.Serilog.csproj
@@ -11,8 +11,8 @@
     <Authors>One Beyond</Authors>
     <Company>One Beyond</Company>
     <Copyright>One Beyond</Copyright>
-    <PackageProjectUrl>https://github.com/guidesmiths/monaco</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/guidesmiths/monaco.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/onebeyond/monaco</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/onebeyond/monaco.git</RepositoryUrl>
     <Description>Library with enrichers and converters for extending Serilog capabilities.</Description>
     <RepositoryType>Git</RepositoryType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Monaco.Template.nuspec
+++ b/src/Monaco.Template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Monaco.Template.Solution</id>
-		<version>1.1.0</version>
+		<version>1.2.0</version>
 		<title>Monaco Solution Template</title>
 		<description>
 			Solution Template for .NET projects
@@ -14,8 +14,8 @@
 			<packageType name="Template" />
 		</packageTypes>
 		<readme>README.md</readme>
-		<projectUrl>https://github.com/guidesmiths/monaco</projectUrl>
-		<repository type="git" url="https://github.com/guidesmiths/monaco" />
+		<projectUrl>https://github.com/onebeyond/monaco</projectUrl>
+		<repository type="git" url="https://github.com/onebeyond/monaco" />
 		<tags>solution project template template-engine csharp</tags>
 	</metadata>
 	<files>

--- a/src/Monaco.Template.nuspec
+++ b/src/Monaco.Template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Monaco.Template.Solution</id>
-		<version>1.2.0</version>
+		<version>1.1.0</version>
 		<title>Monaco Solution Template</title>
 		<description>
 			Solution Template for .NET projects


### PR DESCRIPTION
Renaming links and URLs to point everything towards the new organization where Monaco is hosted: from GuideSmiths to OneBeyond.