### PR TITLE
FIX: Include Encrypt=false on local connection string

### DIFF
--- a/src/Content/Monaco.Template.Api/appsettings.Development.json
+++ b/src/Content/Monaco.Template.Api/appsettings.Development.json
@@ -1,4 +1,8 @@
 {
+	"ConnectionStrings": {
+		"AppDbContext": "Server=.;Initial Catalog=MonacoTemplate;Integrated Security=true;Encrypt=False;"
+	},
+
 	"EnableEFSensitiveLogging": true,
 
 	//#if (!disableAuth)

--- a/src/Content/Monaco.Template.Api/appsettings.json
+++ b/src/Content/Monaco.Template.Api/appsettings.json
@@ -2,7 +2,7 @@
 	"AllowedHosts": "*",
 
 	"ConnectionStrings": {
-		"AppDbContext": "Server=.;Initial Catalog=MonacoTemplate;Integrated Security=true;"
+		"AppDbContext": ""
 	},
 
 	"CorsPolicies": [


### PR DESCRIPTION
Because of [one EF Core 7 breaking change](https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-7.0/breaking-changes#encrypt-defaults-to-true-for-sql-server-connections), the `Encrypt` option for SQL Server connections is enabled by default. In order to mitigate inconveniences for local development environments, the default connection string is moved to `appsettings.Development.json` where it includes the `Encrypt=false` flag.
If the developer wants to enforce this or not on a Release build, it's up to them when building the solution.