### PR TITLE
FEAT: Replaced System.Drawing implementation.

### DIFF
--- a/src/Content/Monaco.Template.Application.Infrastructure.Migrations/Monaco.Template.Application.Infrastructure.Migrations.csproj
+++ b/src/Content/Monaco.Template.Application.Infrastructure.Migrations/Monaco.Template.Application.Infrastructure.Migrations.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Migrations\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Monaco.Template.Application.Infrastructure\Monaco.Template.Application.Infrastructure.csproj" />
   </ItemGroup>
 

--- a/src/Content/Monaco.Template.Application.Infrastructure/EntityConfigurations/ImageEntityConfiguration.cs
+++ b/src/Content/Monaco.Template.Application.Infrastructure/EntityConfigurations/ImageEntityConfiguration.cs
@@ -1,6 +1,6 @@
-﻿using Monaco.Template.Domain.Model;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Monaco.Template.Domain.Model;
 
 namespace Monaco.Template.Application.Infrastructure.EntityConfigurations;
 
@@ -8,14 +8,20 @@ public class ImageEntityConfiguration : IEntityTypeConfiguration<Image>
 {
     public void Configure(EntityTypeBuilder<Image> builder)
     {
-        builder.Property(x => x.DateTaken)
-               .IsRequired(false);
-
-        builder.Property(x => x.Height)
-               .IsRequired();
+		builder.Property(x => x.Height)
+			   .IsRequired();
 
         builder.Property(x => x.Width)
                .IsRequired();
+
+		builder.Property(x => x.DateTaken)
+			   .IsRequired(false);
+
+		builder.Property(x => x.GpsLatitude)
+			   .IsRequired(false);
+
+		builder.Property(x => x.GpsLongitude)
+			   .IsRequired(false);
 
         builder.HasOne(x => x.Thumbnail)
                .WithOne()

--- a/src/Content/Monaco.Template.Application.Infrastructure/Monaco.Template.Application.Infrastructure.csproj
+++ b/src/Content/Monaco.Template.Application.Infrastructure/Monaco.Template.Application.Infrastructure.csproj
@@ -14,8 +14,4 @@
 		<ProjectReference Include="..\Monaco.Template.Domain\Monaco.Template.Domain.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="System.Drawing.Common" Version="7.0.0" />
-	</ItemGroup>
-
 </Project>

--- a/src/Content/Monaco.Template.Application.Tests/Monaco.Template.Application.Tests.csproj
+++ b/src/Content/Monaco.Template.Application.Tests/Monaco.Template.Application.Tests.csproj
@@ -26,10 +26,4 @@
     <ProjectReference Include="..\Monaco.Template.Common.Tests\Monaco.Template.Common.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Features\File\Commands" />
-    <Folder Include="Features\File\Queries" />
-    <Folder Include="Features\Image\Queries" />
-  </ItemGroup>
-
 </Project>

--- a/src/Content/Monaco.Template.Application.Tests/Services/FileServiceTests.cs
+++ b/src/Content/Monaco.Template.Application.Tests/Services/FileServiceTests.cs
@@ -1,0 +1,41 @@
+﻿using MockQueryable.Moq;
+using Monaco.Template.Application.Infrastructure.Context;
+using Monaco.Template.Application.Services;
+using Monaco.Template.Common.BlobStorage.Contracts;
+using Monaco.Template.Domain.Model;
+using Moq;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using File = System.IO.File;
+
+namespace Monaco.Template.Application.Tests.Services;
+
+[ExcludeFromCodeCoverage]
+public class FileServiceTests
+{
+	[Trait("Application Services", "File Service")]
+	[Fact(DisplayName = "Upload image succeeds")]
+	public async Task UploadImageSucceeds()
+	{
+		var dbContextMock = new Mock<AppDbContext>();
+		var imageDbSetMock = new List<Image>().AsQueryable().BuildMockDbSet();
+		dbContextMock.Setup(x => x.Set<Image>())
+					 .Returns(imageDbSetMock.Object);
+		var blobStorageServiceMock = new Mock<IBlobStorageService>();
+		
+		var sut = new FileService(dbContextMock.Object, blobStorageServiceMock.Object);
+
+		await using var stream = File.OpenRead("..\\..\\..\\..\\..\\..\\monaco-solid.png");
+		await sut.UploadImage(stream, "monaco-solid.png", "image/png", CancellationToken.None);
+		stream.Close();
+
+		blobStorageServiceMock.Verify(x => x.UploadTempFileAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+		dbContextMock.Verify(x => x.Set<Image>().AddAsync(It.IsAny<Image>(), It.IsAny<CancellationToken>()));
+		dbContextMock.Verify(x => x.SaveEntitiesAsync(It.IsAny<CancellationToken>()));
+	}
+}

--- a/src/Content/Monaco.Template.Application/Monaco.Template.Application.csproj
+++ b/src/Content/Monaco.Template.Application/Monaco.Template.Application.csproj
@@ -12,11 +12,17 @@
   </ItemGroup>
 
   <ItemGroup>
+	<!--#if (filesSupport)-->
+    <PackageReference Include="ExifLibNet" Version="2.1.4" />
+	<!--#endif-->
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.2.2" />
     <!--#if (massTransitIntegration)-->
     <PackageReference Include="MassTransit" Version="8.0.8" />
     <!--#endif-->
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+	<!--#if (filesSupport)-->
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+	<!--#endif-->
   </ItemGroup>
 
 </Project>

--- a/src/Content/Monaco.Template.Application/Services/Contracts/IFileService.cs
+++ b/src/Content/Monaco.Template.Application/Services/Contracts/IFileService.cs
@@ -1,4 +1,6 @@
-﻿using Monaco.Template.Domain.Model;
+﻿using ExifLibrary;
+using Monaco.Template.Domain.Model;
+using SkiaSharp;
 using File = Monaco.Template.Domain.Model.File;
 
 namespace Monaco.Template.Application.Services.Contracts;
@@ -13,6 +15,6 @@ public interface IFileService
 	Task MakePermanentDocument(Document file, CancellationToken cancellationToken);
 	Task Delete(Guid id, CancellationToken cancellationToken);
 	Task<File> CopyFile(Guid id, CancellationToken cancellationToken);
-	DateTime? GetDateTaken(System.Drawing.Image image);
-	System.Drawing.Image GetThumbnail(System.Drawing.Image image, int thumbnailWidth, int thumbnailHeight);
+	ExifPropertyCollection<ExifProperty> GetMetadata(Stream stream);
+	SKImage GetThumbnail(SKImage image, int thumbnailWidth, int thumbnailHeight);
 }

--- a/src/Content/Monaco.Template.Domain/Model/Image.cs
+++ b/src/Content/Monaco.Template.Domain/Model/Image.cs
@@ -6,26 +6,32 @@ public class Image : File
     {
     }
 
-    public Image(Guid id,
-                 string name,
-                 string extension,
-                 long size,
-                 string contentType,
-                 bool isTemp,
-                 int height,
-                 int width,
-                 DateTime? dateTaken = null,
-                 Image? thumbnail = null) : base(id, name, extension, size, contentType, isTemp)
-    {
-        Height = height;
-        Width = width;
-        DateTaken = dateTaken;
-        Thumbnail = thumbnail;
-    }
+	public Image(Guid id,
+				 string name,
+				 string extension,
+				 long size,
+				 string contentType,
+				 bool isTemp,
+				 int height,
+				 int width,
+				 DateTime? dateTaken = null,
+				 float? gpsLatitude = null,
+				 float? gpsLongitude = null,
+				 Image? thumbnail = null) : base(id, name, extension, size, contentType, isTemp)
+	{
+		Height = height;
+		Width = width;
+		DateTaken = dateTaken;
+		GpsLatitude = gpsLatitude;
+		GpsLongitude = gpsLongitude;
+		Thumbnail = thumbnail;
+	}
 
-    public DateTime? DateTaken { get; private set; }
+	public DateTime? DateTaken { get; private set; }
     public int Height { get; private set; }
     public int Width { get; private set; }
+	public float? GpsLatitude { get; private set; }
+	public float? GpsLongitude { get; private set; }
 
     public Guid? ThumbnailId { get; private set; }
     public virtual Image? Thumbnail { get; private set; }


### PR DESCRIPTION
Closes #5 
Implements `SkiaSharp` to replace `System.Drawing` package for resizing images and obtain thumbnails. It also implements `ExifLibNet` to obtain metadata from images such as Date Taken and GPS Latitude/Longitude.
This should allow better cross-OS implementation of the solution.
Added GPS Latitude/Longitude to the `Image` entity sample.