### PR TITLE
CHORE: NuGet version bump after licensing upgrade

### DIFF
--- a/src/Monaco.Template.nuspec
+++ b/src/Monaco.Template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Monaco.Template.Solution</id>
-		<version>1.2.0</version>
+		<version>1.2.1</version>
 		<title>Monaco Solution Template</title>
 		<description>
 			Solution Template for .NET projects


### PR DESCRIPTION
Applies @CesarD [comment](https://github.com/onebeyond/monaco/pull/34#issuecomment-1382815417) about bumping the NuGet version due to recent licensing changes #34 