### PR TITLE
FIX: Can't properly filter by nullable primitive datatypes

### DIFF
--- a/src/Monaco.Template.nuspec
+++ b/src/Monaco.Template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Monaco.Template</id>
-		<version>2.0.1</version>
+		<version>2.0.2</version>
 		<title>Monaco Template</title>
 		<description>
 			Templates for .NET projects


### PR DESCRIPTION
## Description
Fixed #39 by adding validations that include nullable types and also evaluates the underlying type of an eventually nullable value.
It also fixes another scenario where when comparing non-nullable types against a null value it threw an exception.

## Related Issue
Fixes #39

## Motivation and Context
Fixes a reported bug.

## How Has This Been Tested?
Tested different scenarios via Postman directly against the API.

## Screenshots (if appropriate):
N/A

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
