### PR TITLE
FEAT: Remove remaining System.Drawing dependency

### DIFF
--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Api/Monaco.Template.Backend.Api.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Api/Monaco.Template.Backend.Api.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
     <!--#if (massTransitIntegration)-->
-    <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="8.0.12" />
-    <PackageReference Include="MassTransit.RabbitMQ" Version="8.0.12" />
+    <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="8.0.13" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.0.13" />
     <!--#endif-->
 	<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Commands/CompanyCommandsHandlersTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Commands/CompanyCommandsHandlersTests.cs
@@ -16,9 +16,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Application.Tests.Features.Company.Commands;
 
 [ExcludeFromCodeCoverage]
+[Trait("Application Commands", "Company Commands")]
 public class CompanyCommandsHandlersTests
 {
-	[Trait("Application Commands", "Company Commands")]
 	[Theory(DisplayName = "Create new company succeeds")]
 	[AnonymousData]
 	public async Task CreateNewCompanySucceeds(Domain.Model.Country country)
@@ -48,7 +48,6 @@ public class CompanyCommandsHandlersTests
 		result.ItemNotFound.Should().BeFalse();
 	}
 
-	[Trait("Application Commands", "Company Commands")]
 	[Theory(DisplayName = "Edit company succeeds")]
 	[AnonymousData]
 	public async Task EditCompanySucceeds(Domain.Model.Country country)

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Commands/Validators/CompanyCreateCommandValidatorTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Commands/Validators/CompanyCreateCommandValidatorTests.cs
@@ -17,9 +17,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Application.Tests.Features.Company.Commands.Validators;
 
 [ExcludeFromCodeCoverage]
+[Trait("Application Validators", "Company Validators")]
 public class CompanyCreateCommandValidatorTests
 {
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Validator's rule level cascade mode is 'Stop'")]
 	public void ValidatorRuleLevelCascadeModeIsStop()
 	{
@@ -28,7 +28,6 @@ public class CompanyCreateCommandValidatorTests
 		sut.RuleLevelCascadeMode.Should().Be(CascadeMode.Stop);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Name being valid does not generate validation error")]
 	public async Task NameDoesNotGenerateErrorWhenValid()
 	{
@@ -52,7 +51,6 @@ public class CompanyCreateCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.Name);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Name with empty value generates validation error")]
 	public async Task NameIsEmptyGeneratesError()
 	{
@@ -74,7 +72,6 @@ public class CompanyCreateCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Name with long value generates validation error")]
 	public async Task NameWithLongValueGeneratesError()
 	{
@@ -97,7 +94,6 @@ public class CompanyCreateCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Name which already exists generates validation error")]
 	[AnonymousData]
 	public async Task NameAlreadyExistsGeneratesError(Domain.Model.Company company)
@@ -125,7 +121,6 @@ public class CompanyCreateCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Email being valid does not generate validation error")]
 	public async Task EmailIsValidDoesNotGenerateError()
 	{
@@ -149,7 +144,6 @@ public class CompanyCreateCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.Email);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Email with empty value generates validation error")]
 	public async Task EmailIsEmptyGeneratesError()
 	{
@@ -171,7 +165,6 @@ public class CompanyCreateCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Email being invalid generates validation error")]
 	[AnonymousData]
 	public async Task EmailAddressIsInvalidGeneratesError(string email)
@@ -194,7 +187,6 @@ public class CompanyCreateCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Website URL with long value generates validation error")]
 	public async Task WebsiteUrlWithLongValueGeneratesError()
 	{
@@ -217,7 +209,6 @@ public class CompanyCreateCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Website URL with empty value does not generate validation error")]
 	public async Task WebsiteUrlWithEmptyValueDoesNotGenerateError()
 	{
@@ -236,9 +227,8 @@ public class CompanyCreateCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.WebSiteUrl);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Street with long value generates validation error")]
-	public async Task AddressWithLongValueGeneratesError()
+	public async Task StreetWithLongValueGeneratesError()
 	{
 		var cmdMock = new Mock<CompanyCreateCommand>(It.IsAny<string>(),                // Name
 													 It.IsAny<string>(),                // Email
@@ -259,9 +249,8 @@ public class CompanyCreateCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Street with empty value does not generate validation error")]
-	public async Task AddressWithEmptyValueDoesNotGenerateError()
+	public async Task StreetWithEmptyValueDoesNotGenerateError()
 	{
 		var cmdMock = new Mock<CompanyCreateCommand>(It.IsAny<string>(),    // Name
 													 It.IsAny<string>(),    // Email
@@ -278,7 +267,6 @@ public class CompanyCreateCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.Street);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "City with long value generates validation error")]
 	public async Task CityWithLongValueGeneratesError()
 	{
@@ -301,7 +289,6 @@ public class CompanyCreateCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "City with empty value does not generate validation error")]
 	public async Task CityWithEmptyValueDoesNotGenerateError()
 	{
@@ -320,7 +307,6 @@ public class CompanyCreateCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.City);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "County with long value generates validation error")]
 	public async Task CountyWithLongValueGeneratesError()
 	{
@@ -343,7 +329,6 @@ public class CompanyCreateCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "County with empty value does not generate validation error")]
 	public async Task CountyWithEmptyValueDoesNotGenerateError()
 	{
@@ -362,7 +347,6 @@ public class CompanyCreateCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.County);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Postcode with long value generates validation error")]
 	public async Task PostcodeWithLongValueGeneratesError()
 	{
@@ -385,7 +369,6 @@ public class CompanyCreateCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Postcode with empty value does not generate validation error")]
 	public async Task PostcodeWithEmptyValueDoesNotGenerateError()
 	{
@@ -404,7 +387,6 @@ public class CompanyCreateCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.PostCode);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Country being valid does not generate validation error")]
 	[AnonymousData(true)]
 	public async Task CountryIsValidDoesNotGenerateError(Domain.Model.Country country)
@@ -436,7 +418,6 @@ public class CompanyCreateCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.CountryId);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Country with null value does not generate validation error when Address fields null")]
 	public async Task CountryWithNullValueDoesNotGenerateErrorWhenAddressFieldsNull()
 	{
@@ -459,7 +440,6 @@ public class CompanyCreateCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.CountryId);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Country with null value generates validation error when Address fields present")]
 	public async Task CountryWithNullValueGeneratesErrorWhenAddressFieldsPresent()
 	{
@@ -482,7 +462,6 @@ public class CompanyCreateCommandValidatorTests
 		validationResult.ShouldHaveValidationErrorFor(cmd => cmd.CountryId);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Country that doesn't exist generates validation error")]
 	[AnonymousData]
 	public async Task CountryMustExistValidation(Domain.Model.Country country)

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Commands/Validators/CompanyDeleteCommandValidatorTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Commands/Validators/CompanyDeleteCommandValidatorTests.cs
@@ -18,9 +18,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Application.Tests.Features.Company.Commands.Validators;
 
 [ExcludeFromCodeCoverage]
+[Trait("Application Validators", "Company Validators")]
 public class CompanyDeleteCommandValidatorTests
 {
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Validator's rule level cascade mode is 'Stop'")]
 	public void ValidatorRuleLevelCascadeModeIsStop()
 	{
@@ -29,7 +29,6 @@ public class CompanyDeleteCommandValidatorTests
 		sut.RuleLevelCascadeMode.Should().Be(CascadeMode.Stop);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Existing company passes validation correctly")]
 	[AnonymousData]
 	public async Task ExistingCompanyPassesValidationCorrectly(Domain.Model.Company company)
@@ -46,7 +45,6 @@ public class CompanyDeleteCommandValidatorTests
 		validationResult.ShouldNotHaveAnyValidationErrors();
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Non existing company passes validation correctly")]
 	[AnonymousData]
 	public async Task NonExistingCompanyPassesValidationCorrectly(Domain.Model.Company company, Guid id)

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Commands/Validators/CompanyEditCommandValidatorTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Commands/Validators/CompanyEditCommandValidatorTests.cs
@@ -18,9 +18,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Application.Tests.Features.Company.Commands.Validators;
 
 [ExcludeFromCodeCoverage]
+[Trait("Application Validators", "Company Validators")]
 public class CompanyEditCommandValidatorTests
 {
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Validator's rule level cascade mode is 'Stop'")]
 	public void ValidatorRuleLevelCascadeModeIsStop()
 	{
@@ -29,7 +29,6 @@ public class CompanyEditCommandValidatorTests
 		sut.RuleLevelCascadeMode.Should().Be(CascadeMode.Stop);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Existing company passes validation correctly")]
 	[AnonymousData]
 	public async Task ExistingCompanyPassesValidationCorrectly(Domain.Model.Company company)
@@ -54,7 +53,6 @@ public class CompanyEditCommandValidatorTests
 		validationResult.ShouldNotHaveAnyValidationErrors();
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Non existing company passes validation correctly")]
 	[AnonymousData]
 	public async Task NonExistingCompanyPassesValidationCorrectly(Domain.Model.Company company, Guid id)
@@ -79,7 +77,6 @@ public class CompanyEditCommandValidatorTests
 		validationResult.ShouldHaveValidationErrorFor(x => x.Id);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Name being valid does not generate validation error")]
 	public async Task NameDoesNotGenerateErrorWhenValid()
 	{
@@ -88,15 +85,15 @@ public class CompanyEditCommandValidatorTests
 		var companyDbSetMock = new List<Domain.Model.Company>().AsQueryable().BuildMockDbSet();
 		dbContextMock.Setup(x => x.Set<Domain.Model.Company>()).Returns(companyDbSetMock.Object);
 
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),					// Id
 												   new string(It.IsAny<char>(), 100),   // same Name as the already-existing Company
-												   It.IsAny<string>(),              // Email
-												   It.IsAny<string>(),              // WebSiteUrl
-												   It.IsAny<string>(),              // Street
-												   It.IsAny<string>(),              // City
-												   It.IsAny<string>(),              // County
-												   It.IsAny<string>(),              // PostCode
-												   It.IsAny<Guid>());                   // country.Id
+												   It.IsAny<string>(),					// Email
+												   It.IsAny<string>(),					// WebSiteUrl
+												   It.IsAny<string>(),					// Street
+												   It.IsAny<string>(),					// City
+												   It.IsAny<string>(),					// County
+												   It.IsAny<string>(),					// PostCode
+												   It.IsAny<Guid>());					// country.Id
 
 		var sut = new CompanyEditCommandValidator(dbContextMock.Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.Name));
@@ -104,19 +101,18 @@ public class CompanyEditCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.Name);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Name with empty value generates validation error")]
 	public async Task NameIsEmptyGeneratesError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   string.Empty,            // Name
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
+												   string.Empty,        // Name
 												   It.IsAny<string>(),  // Email
 												   It.IsAny<string>(),  // WebSiteUrl
 												   It.IsAny<string>(),  // Street
 												   It.IsAny<string>(),  // City
 												   It.IsAny<string>(),  // County
 												   It.IsAny<string>(),  // PostCode
-												   It.IsAny<Guid>());       // country.Id
+												   It.IsAny<Guid>());   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.Name));
@@ -127,18 +123,17 @@ public class CompanyEditCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Name with long value generates validation error")]
 	public async Task NameWithLongValueGeneratesError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),					// Id
 												   new string(It.IsAny<char>(), 101),   // Name
-												   It.IsAny<string>(),              // Email
-												   It.IsAny<string>(),              // WebSiteUrl
-												   It.IsAny<string>(),              // Street
-												   It.IsAny<string>(),              // City
-												   It.IsAny<string>(),              // County
-												   It.IsAny<string>(),              // PostCode
+												   It.IsAny<string>(),					// Email
+												   It.IsAny<string>(),					// WebSiteUrl
+												   It.IsAny<string>(),					// Street
+												   It.IsAny<string>(),					// City
+												   It.IsAny<string>(),					// County
+												   It.IsAny<string>(),					// PostCode
 												   It.IsAny<Guid>());                   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
@@ -151,7 +146,6 @@ public class CompanyEditCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Name which already exists generates validation error")]
 	[AnonymousData]
 	public async Task NameAlreadyExistsGeneratesError(Domain.Model.Company company, Guid id)
@@ -161,15 +155,15 @@ public class CompanyEditCommandValidatorTests
 		var companyDbSetMock = new List<Domain.Model.Company> { company }.AsQueryable().BuildMockDbSet();
 		dbContextMock.Setup(x => x.Set<Domain.Model.Company>()).Returns(companyDbSetMock.Object);
 
-		var cmdMock = new Mock<CompanyEditCommand>(id,
-												   company.Name,          // same Name as the already-existing Company
+		var cmdMock = new Mock<CompanyEditCommand>(id,					// Id
+												   company.Name,        // same Name as the already-existing Company
 												   It.IsAny<string>(),  // Email
 												   It.IsAny<string>(),  // WebSiteUrl
 												   It.IsAny<string>(),  // Street
 												   It.IsAny<string>(),  // City
-												   It.IsAny<string>(),    // County
+												   It.IsAny<string>(),  // County
 												   It.IsAny<string>(),  // PostCode
-												   It.IsAny<Guid>());       // country.Id
+												   It.IsAny<Guid>());   // country.Id
 
 		var sut = new CompanyEditCommandValidator(dbContextMock.Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.Name));
@@ -180,7 +174,6 @@ public class CompanyEditCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Email being valid does not generate validation error")]
 	public async Task EmailIsValidDoesNotGenerateError()
 	{
@@ -189,15 +182,15 @@ public class CompanyEditCommandValidatorTests
 		var companyDbSetMock = new List<Domain.Model.Company>().AsQueryable().BuildMockDbSet();
 		dbContextMock.Setup(x => x.Set<Domain.Model.Company>()).Returns(companyDbSetMock.Object);
 
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
 												   It.IsAny<string>(),  // same Name as the already-existing Company
-												   "valid@email.com",       // Email
+												   "valid@email.com",   // Email
 												   It.IsAny<string>(),  // WebSiteUrl
 												   It.IsAny<string>(),  // Street
 												   It.IsAny<string>(),  // City
 												   It.IsAny<string>(),  // County
 												   It.IsAny<string>(),  // PostCode
-												   It.IsAny<Guid>());       // country.Id
+												   It.IsAny<Guid>());   // country.Id
 
 		var sut = new CompanyEditCommandValidator(dbContextMock.Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.Email));
@@ -205,19 +198,18 @@ public class CompanyEditCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.Email);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Email with empty value generates validation error")]
 	public async Task EmailIsEmptyGeneratesError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
 												   It.IsAny<string>(),  // Name
-												   string.Empty,            // Email
+												   string.Empty,		// Email
 												   It.IsAny<string>(),  // WebSiteUrl
 												   It.IsAny<string>(),  // Street
 												   It.IsAny<string>(),  // City
 												   It.IsAny<string>(),  // County
 												   It.IsAny<string>(),  // PostCode
-												   It.IsAny<Guid>());       // country.Id
+												   It.IsAny<Guid>());   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.Email));
@@ -228,20 +220,19 @@ public class CompanyEditCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Email being invalid generates validation error")]
 	[AnonymousData]
 	public async Task EmailAddressIsInvalidGeneratesError(string email)
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
 												   It.IsAny<string>(),  // Name
-												   email,                   // Email
+												   email,               // Email
 												   It.IsAny<string>(),  // WebSiteUrl
 												   It.IsAny<string>(),  // Street
 												   It.IsAny<string>(),  // City
 												   It.IsAny<string>(),  // County
 												   It.IsAny<string>(),  // PostCode
-												   It.IsAny<Guid>());       // country.Id
+												   It.IsAny<Guid>());   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.Email));
@@ -252,18 +243,17 @@ public class CompanyEditCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Website URL with long value generates validation error")]
 	public async Task WebsiteUrlWithLongValueGeneratesError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   It.IsAny<string>(),              // Name
-												   It.IsAny<string>(),              // Email
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),					// Id
+												   It.IsAny<string>(),					// Name
+												   It.IsAny<string>(),					// Email
 												   new string(It.IsAny<char>(), 301),   // WebSiteUrl
-												   It.IsAny<string>(),              // Street
-												   It.IsAny<string>(),              // City
-												   It.IsAny<string>(),              // County
-												   It.IsAny<string>(),              // PostCode
+												   It.IsAny<string>(),					// Street
+												   It.IsAny<string>(),					// City
+												   It.IsAny<string>(),					// County
+												   It.IsAny<string>(),					// PostCode
 												   It.IsAny<Guid>());                   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
@@ -276,19 +266,18 @@ public class CompanyEditCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Website URL with empty value does not generate validation error")]
 	public async Task WebsiteUrlWithEmptyValueDoesNotGenerateError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   It.IsAny<string>(),    // Name
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
+												   It.IsAny<string>(),  // Name
 												   It.IsAny<string>(),  // Email
-												   string.Empty,            // WebSiteUrl
+												   string.Empty,        // WebSiteUrl
 												   It.IsAny<string>(),  // Street
 												   It.IsAny<string>(),  // City
 												   It.IsAny<string>(),  // County
 												   It.IsAny<string>(),  // PostCode
-												   It.IsAny<Guid>());       // country.Id
+												   It.IsAny<Guid>());   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.WebSiteUrl));
@@ -296,18 +285,17 @@ public class CompanyEditCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.WebSiteUrl);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Street with long value generates validation error")]
 	public async Task AddressWithLongValueGeneratesError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   It.IsAny<string>(),                // Name
-												   It.IsAny<string>(),              // Email
-												   It.IsAny<string>(),              // WebSiteUrl
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),					// Id
+												   It.IsAny<string>(),					// Name
+												   It.IsAny<string>(),					// Email
+												   It.IsAny<string>(),					// WebSiteUrl
 												   new string(It.IsAny<char>(), 101),   // Street
-												   It.IsAny<string>(),              // City
-												   It.IsAny<string>(),              // County
-												   It.IsAny<string>(),              // PostCode
+												   It.IsAny<string>(),					// City
+												   It.IsAny<string>(),					// County
+												   It.IsAny<string>(),					// PostCode
 												   It.IsAny<Guid>());                   // country.Id
 
 		var validator = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
@@ -320,19 +308,18 @@ public class CompanyEditCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Street with empty value does not generate validation error")]
 	public async Task AddressWithEmptyValueDoesNotGenerateError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   It.IsAny<string>(),    // Name
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
+												   It.IsAny<string>(),  // Name
 												   It.IsAny<string>(),  // Email
 												   It.IsAny<string>(),  // WebSiteUrl
-												   string.Empty,            // Street
+												   string.Empty,        // Street
 												   It.IsAny<string>(),  // City
 												   It.IsAny<string>(),  // County
 												   It.IsAny<string>(),  // PostCode
-												   It.IsAny<Guid>());       // country.Id
+												   It.IsAny<Guid>());	// country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.Street));
@@ -340,18 +327,17 @@ public class CompanyEditCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.Street);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "City with long value generates validation error")]
 	public async Task CityWithLongValueGeneratesError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   It.IsAny<string>(),                // Name
-												   It.IsAny<string>(),              // Email
-												   It.IsAny<string>(),              // WebSiteUrl
-												   It.IsAny<string>(),              // Street
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),					// Id
+												   It.IsAny<string>(),					// Name
+												   It.IsAny<string>(),					// Email
+												   It.IsAny<string>(),					// WebSiteUrl
+												   It.IsAny<string>(),					// Street
 												   new string(It.IsAny<char>(), 101),   // City
-												   It.IsAny<string>(),              // County
-												   It.IsAny<string>(),              // PostCode
+												   It.IsAny<string>(),					// County
+												   It.IsAny<string>(),					// PostCode
 												   It.IsAny<Guid>());                   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
@@ -364,19 +350,18 @@ public class CompanyEditCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "City with empty value does not generate validation error")]
 	public async Task CityWithEmptyValueDoesNotGenerateError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   It.IsAny<string>(),    // Name
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
+												   It.IsAny<string>(),  // Name
 												   It.IsAny<string>(),  // Email
 												   It.IsAny<string>(),  // WebSiteUrl
 												   It.IsAny<string>(),  // Street
-												   string.Empty,            // City
+												   string.Empty,        // City
 												   It.IsAny<string>(),  // County
 												   It.IsAny<string>(),  // PostCode
-												   It.IsAny<Guid>());       // country.Id
+												   It.IsAny<Guid>());   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.City));
@@ -384,18 +369,17 @@ public class CompanyEditCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.City);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "County with long value generates validation error")]
 	public async Task CountyWithLongValueGeneratesError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   It.IsAny<string>(),                // Name
-												   It.IsAny<string>(),              // Email
-												   It.IsAny<string>(),              // WebSiteUrl
-												   It.IsAny<string>(),              // Street
-												   It.IsAny<string>(),              // City
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),					// Id
+												   It.IsAny<string>(),					// Name
+												   It.IsAny<string>(),					// Email
+												   It.IsAny<string>(),					// WebSiteUrl
+												   It.IsAny<string>(),					// Street
+												   It.IsAny<string>(),					// City
 												   new string(It.IsAny<char>(), 101),   // County
-												   It.IsAny<string>(),              // PostCode
+												   It.IsAny<string>(),					// PostCode
 												   It.IsAny<Guid>());                   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
@@ -408,19 +392,18 @@ public class CompanyEditCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "County with empty value does not generate validation error")]
 	public async Task CountyWithEmptyValueDoesNotGenerateError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   It.IsAny<string>(),        // Name
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
+												   It.IsAny<string>(),  // Name
 												   It.IsAny<string>(),  // Email
 												   It.IsAny<string>(),  // WebSiteUrl
 												   It.IsAny<string>(),  // Street
 												   It.IsAny<string>(),  // City
-												   string.Empty,            // County
+												   string.Empty,        // County
 												   It.IsAny<string>(),  // PostCode
-												   It.IsAny<Guid>());       // country.Id
+												   It.IsAny<Guid>());   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.County));
@@ -428,18 +411,17 @@ public class CompanyEditCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.County);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Postcode with long value generates validation error")]
 	public async Task PostcodeWithLongValueGeneratesError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   It.IsAny<string>(),                // Name
-												   It.IsAny<string>(),              // Email
-												   It.IsAny<string>(),              // WebSiteUrl
-												   It.IsAny<string>(),              // Street
-												   It.IsAny<string>(),              // City
-												   It.IsAny<string>(),              // County
-												   new string(It.IsAny<char>(), 11),    // PostCode
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),					// Id
+												   It.IsAny<string>(),					// Name
+												   It.IsAny<string>(),					// Email
+												   It.IsAny<string>(),					// WebSiteUrl
+												   It.IsAny<string>(),					// Street
+												   It.IsAny<string>(),					// City
+												   It.IsAny<string>(),					// County
+												   new string(It.IsAny<char>(), 11),	// PostCode
 												   It.IsAny<Guid>());                   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
@@ -452,19 +434,18 @@ public class CompanyEditCommandValidatorTests
 						.HaveCount(1);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Postcode with empty value does not generate validation error")]
 	public async Task PostcodeWithEmptyValueDoesNotGenerateError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   It.IsAny<string>(),        // Name
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
+												   It.IsAny<string>(),  // Name
 												   It.IsAny<string>(),  // Email
 												   It.IsAny<string>(),  // WebSiteUrl
 												   It.IsAny<string>(),  // Street
 												   It.IsAny<string>(),  // City
 												   It.IsAny<string>(),  // County
-												   string.Empty,            // PostCode
-												   It.IsAny<Guid>());       // country.Id
+												   string.Empty,        // PostCode
+												   It.IsAny<Guid>());   // country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.PostCode));
@@ -472,7 +453,6 @@ public class CompanyEditCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.PostCode);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Country being valid does not generate validation error")]
 	[AnonymousData(true)]
 	public async Task CountryIsValidDoesNotGenerateError(Domain.Model.Country country)
@@ -485,7 +465,7 @@ public class CompanyEditCommandValidatorTests
 		var countryDbSetMock = new List<Domain.Model.Country>() { country }.AsQueryable().BuildMockDbSet();
 		dbContextMock.Setup(x => x.Set<Domain.Model.Country>()).Returns(countryDbSetMock.Object);
 
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
 												   It.IsAny<string>(),  // Name
 												   It.IsAny<string>(),  // Email
 												   It.IsAny<string>(),  // WebSiteUrl
@@ -501,11 +481,10 @@ public class CompanyEditCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.CountryId);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Fact(DisplayName = "Country with null value does not generate validation error")]
 	public async Task CountryWithNullValueDoesNotGenerateError()
 	{
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
 												   It.IsAny<string>(),  // Name
 												   It.IsAny<string>(),  // Email
 												   It.IsAny<string>(),  // WebSiteUrl
@@ -513,7 +492,7 @@ public class CompanyEditCommandValidatorTests
 												   It.IsAny<string>(),  // City
 												   It.IsAny<string>(),  // County
 												   It.IsAny<string>(),  // PostCode
-												   null);           // country.Id
+												   null);				// country.Id
 
 		var sut = new CompanyEditCommandValidator(new Mock<AppDbContext>().Object);
 		var validationResult = await sut.TestValidateAsync(cmdMock.Object, strategy => strategy.IncludeProperties(cmd => cmd.CountryId));
@@ -521,7 +500,6 @@ public class CompanyEditCommandValidatorTests
 		validationResult.ShouldNotHaveValidationErrorFor(cmd => cmd.CountryId);
 	}
 
-	[Trait("Application Validators", "Company Validators")]
 	[Theory(DisplayName = "Country that doesn't exist generates validation error")]
 	[AnonymousData]
 	public async Task CountryMustExistValidation(Domain.Model.Country country)
@@ -534,14 +512,14 @@ public class CompanyEditCommandValidatorTests
 		var countryDbSetMock = new List<Domain.Model.Country>() { country }.AsQueryable().BuildMockDbSet();
 		dbContextMock.Setup(x => x.Set<Domain.Model.Country>()).Returns(countryDbSetMock.Object);
 
-		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),
-												   It.IsAny<string>(),    // Name
+		var cmdMock = new Mock<CompanyEditCommand>(It.IsAny<Guid>(),	// Id
+												   It.IsAny<string>(),	// Name
 												   It.IsAny<string>(),  // Email
 												   It.IsAny<string>(),  // WebSiteUrl
 												   It.IsAny<string>(),  // Street
 												   It.IsAny<string>(),  // City
 												   It.IsAny<string>(),  // County
-												   It.IsAny<string>(),    // PostCode
+												   It.IsAny<string>(),  // PostCode
 												   Guid.NewGuid());     // country.Id
 
 		var sut = new CompanyEditCommandValidator(dbContextMock.Object);

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Queries/CompanyQueriesHandlersTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Queries/CompanyQueriesHandlersTests.cs
@@ -18,9 +18,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Application.Tests.Features.Company.Queries;
 
 [ExcludeFromCodeCoverage]
+[Trait("Application Queries", "Company Queries")]
 public class CompanyQueriesHandlersTests
 {
-	[Trait("Application Queries", "Company Queries")]
 	[Theory(DisplayName = "Get company page without params succeeds")]
 	[AnonymousData]
 	public async Task GetCompanyPageWithoutParamsSucceeds(List<Domain.Model.Company> companies)
@@ -40,7 +40,6 @@ public class CompanyQueriesHandlersTests
 			  .BeInAscendingOrder(x => x.Name);
 	}
 
-	[Trait("Application Queries", "Company Queries")]
 	[Theory(DisplayName = "Get company page with params succeeds")]
 	[AnonymousData]
 	public async Task GetCompanyPageWithParamsSucceeds(List<Domain.Model.Company> companies)
@@ -82,9 +81,8 @@ public class CompanyQueriesHandlersTests
 		result!.Name.Should().Be(company.Name);
 	}
 
-	[Trait("Application Queries", "Company Queries")]
 	[Fact(DisplayName = "Get non-existing company by Id fails")]
-	public async Task GetNonExistingCountryByIdFails()
+	public async Task GetNonExistingCompanyByIdFails()
 	{
 		var companies = CompanyFactory.CreateMany().ToList();
 		var dbContextMock = SetupMock(companies);
@@ -102,7 +100,6 @@ public class CompanyQueriesHandlersTests
 		var dbContextMock = new Mock<AppDbContext>();
 		dbContextMock.Setup(x => x.Set<Domain.Model.Company>())
 					 .Returns(dbSetMock.Object);
-
 
 		return dbContextMock;
 	}

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Country/Queries/CountryQueriesHandlersTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Country/Queries/CountryQueriesHandlersTests.cs
@@ -18,9 +18,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Application.Tests.Features.Country.Queries;
 
 [ExcludeFromCodeCoverage]
+[Trait("Application Queries", "Country Queries")]
 public class CountryQueriesHandlersTests
 {
-	[Trait("Application Queries", "Country Queries")]
 	[Theory(DisplayName = "Get country list without params succeeds")]
 	[AnonymousData]
 	public async Task GetCountryListWithoutParamsSucceeds(List<Domain.Model.Country> countries)
@@ -37,7 +37,6 @@ public class CountryQueriesHandlersTests
 			  .BeInAscendingOrder(x => x.Name);
 	}
 
-	[Trait("Application Queries", "Country Queries")]
 	[Theory(DisplayName = "Get country list with params succeeds")]
 	[AnonymousData]
 	public async Task GetCountryListWithParamsSucceeds(List<Domain.Model.Country> countries)
@@ -61,7 +60,6 @@ public class CountryQueriesHandlersTests
 			  .BeInDescendingOrder(x => x.Name);
 	}
 
-	[Trait("Application Queries", "Country Queries")]
 	[Fact(DisplayName = "Get existing country by Id succeeds")]
 	public async Task GetExistingCountryByIdSucceeds()
 	{
@@ -77,7 +75,6 @@ public class CountryQueriesHandlersTests
 		result!.Name.Should().Be(country.Name);
 	}
 
-	[Trait("Application Queries", "Country Queries")]
 	[Fact(DisplayName = "Get non-existing country by Id fails")]
 	public async Task GetNonExistingCountryByIdFails()
 	{

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Monaco.Template.Backend.Application.Tests.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Monaco.Template.Backend.Application.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MockQueryable.Moq" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Services/FileServiceTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Services/FileServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using MockQueryable.Moq;
 using Monaco.Template.Backend.Application.Infrastructure.Context;
 using Monaco.Template.Backend.Application.Services;
+using Monaco.Template.Backend.Common.BlobStorage;
 using Monaco.Template.Backend.Common.BlobStorage.Contracts;
 using Monaco.Template.Backend.Domain.Model;
 using Moq;
@@ -16,9 +17,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Application.Tests.Services;
 
 [ExcludeFromCodeCoverage]
+[Trait("Application Services", "File Service")]
 public class FileServiceTests
 {
-	[Trait("Application Services", "File Service")]
 	[Fact(DisplayName = "Upload image succeeds")]
 	public async Task UploadImageSucceeds()
 	{
@@ -38,6 +39,74 @@ public class FileServiceTests
 
 		blobStorageServiceMock.Verify(x => x.UploadTempFileAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
 		dbContextMock.Verify(x => x.Set<Image>().AddAsync(It.IsAny<Image>(), It.IsAny<CancellationToken>()));
+		dbContextMock.Verify(x => x.SaveEntitiesAsync(It.IsAny<CancellationToken>()));
+	}
+
+	[Fact(DisplayName = "Upload document succeeds")]
+	public async Task UploadDocumentSucceeds()
+	{
+		var dbContextMock = new Mock<AppDbContext>();
+		var documentDbSetMock = new List<Document>().AsQueryable().BuildMockDbSet();
+		dbContextMock.Setup(x => x.Set<Document>())
+					 .Returns(documentDbSetMock.Object);
+		var blobStorageServiceMock = new Mock<IBlobStorageService>();
+
+		var sut = new FileService(dbContextMock.Object, blobStorageServiceMock.Object);
+
+		const string txtBase64 = "TW9uYWNvIFVuaXQgVGVzdCBGaWxlIGZvciBVcGxvYWQgZG9jdW1lbnQgc3VjY2VlZHMu";
+
+		await using var stream = new MemoryStream(Convert.FromBase64String(txtBase64));
+		await sut.UploadDocument(stream, "sample-text-file.txt", "text/plain", CancellationToken.None);
+		stream.Close();
+
+		blobStorageServiceMock.Verify(x => x.UploadTempFileAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+		dbContextMock.Verify(x => x.Set<Document>().AddAsync(It.IsAny<Document>(), It.IsAny<CancellationToken>()));
+		dbContextMock.Verify(x => x.SaveEntitiesAsync(It.IsAny<CancellationToken>()));
+	}
+
+	[Fact(DisplayName = "Uploading an image file uploads an image succeeds")]
+	public async Task UploadingImageFileUploadsImageSucceeds()
+	{
+		var dbContextMock = new Mock<AppDbContext>();
+		var imageDbSetMock = new List<Image>().AsQueryable().BuildMockDbSet();
+		dbContextMock.Setup(x => x.Set<Image>())
+					 .Returns(imageDbSetMock.Object);
+		var blobStorageServiceMock = new Mock<IBlobStorageService>();
+		blobStorageServiceMock.Setup(x => x.GetFileType(It.IsAny<string>()))
+							  .Returns(FileTypeEnum.Image);
+
+		var sut = new FileService(dbContextMock.Object, blobStorageServiceMock.Object);
+
+		const string imgBase64 = "iVBORw0KGgoAAAANSUhEUgAAAT4AAABQCAYAAACAsRmuAAAABmJLR0QA/wD/AP+gvaeTAAAeFklEQVR42u3dd3yURf4H8LWcenoiFkCKCgEE9afo3aGnd4flPOshinJ6gAKCCFKkSyeUhJ5GekgvpBMSEpKQhEB67z1h07PZJNs3Pfn+nucJWRNmtm82ITvzen3+EOThYTf73plnZr7DYo1As50lXmY7Swg2sgiYWM/iDwkPLswcTBsTKyatsljObAHLFwbDBQtZmpmYM+GA+fODaQIzJo2ynH++Ac4/N5h6OCdLHZOzTGrh7IyBnJlRMyTVcFoWNpyezoZTTG4PSRWcZFI5kGmVYDqtYkjKwUSWMiYnptIpleX41JIhKYZjdJ6lU8TkKJPCOykAYzpT6OTLcmRK3pDkwmE6k+nkMDnEJFuWg5OzBjKJTiYckCWDyf5J6b/nmTTYJ0sqk71MUn7P08nwmyxJTPYwSZRl91MJQ3ILdjG5KcvOJ+OH5AbskCWOyXY6E2OHJAa2yXKdya90noiWZesTUXcSyWQLk2uwZcJANk+IGJJw2CTLVdj0+FX4hUmYLBsfDx2SK7DxT1dgA5OQO7kMP8sSDD8/FgzrmQTJ8tNjgUMSAOseHYw/k7VM/GT58VFf+PGPg7kEa2TxuRNvWE3nETpeTFYx8ZTlh0c8BvIwHXf4XhY3JiuZuA7kIVdY8ZDLkDjDciYXB/IHOk7wP1kcmXzHxGEgDzrAtw/aD4kd/FcWWybLHqBjI8s3D1jfyQUmX9O530qWpfdbDokFk6/o3Gcuy5f3mQ3JeVgyGNY5Jl8wOQs6R896vuhpGyMRh8BH4CPwEfgMBj4bI7GXrZEICHwEPgIfgc8g4LM1En7OoEfgI/AR+Ah8hgCfgxHvCTsjUR2Bj8BH4CPwGQx8dkYSZxl6BD4CH4GPwDfe4bObLf7AzkjcT+Aj8BH4CHwGAZ/HFM5jdrPEVRR8QOAj8BH4CHwGAR8Fng2NHoGPwEfgI/AZBHw2s0XvUOD1EfgIfAQ+Ap9BwOcwDR6lJjTKB9Ej8BH4CHwEvnEPn62R5DwFHxD4CHwEPgKfQcDnMLP9LQq9XgIfgY/AR+AzCPis5sDD9kaSwgH0CHwEPgIfgc8A4LM3kpray9Aj8BH4CHwEvnEOn+Ncyev2s6XdBD4CH4GPwGcQ8Bm/Bw9S6GVRAQIfgY/AR+AzCPgcjKRHGPQIfAQ+Ah+BzxDgc5rb9RIFXieBj8BH4CPwGQR8/ix4wGF2e7oMPQIfgY/AR+Ab7/DZG7X/RsEHIwmfx7t86O2CEW31aV0UggQ+Ah+Bj8CnBD7bWZ3zKPTaRxq+qqgRVu9OC9vYRuDTEL79k9Pg2JwsMJ6VQeAbg/D9PMkPNj0bAD/+yXvU4Fv1hAusnUxd5zGnexc+YxbcT4GXQKM3kvBdXi7SC3r9/QDipl6wfLFBr/DZvMWGohARFIeJqYiYZLnz4fTscp3Bd+1AAxSGCoaEDz6r2FrBd+G9Qog5Uw9VCUKQtPYMfy37AFrZHVAU3gYhu2+DySuZWsEXerAK8kK4kHsnOUHUo4wPMrWGz/zfaZAd3AQ5lzlUmpj47yrWCXxbJ12FRNdqyApuuCv14Ph9+ojCt3laELhsSIO0gBpoKhdBX0//sPdHwu+CihQuRJgVgemHUVRvUPfwrZnoClbLY+GWVwXUFvKgp6tv2D20i7qhIr0ZIqzy4cTHYfDdQ/b3BnwORu3bBtEbKfhsZvOgrayX+iQN/VRpl/47kdeSzgv1Cp/fygbsfaQ783QCn+e3t7H/3nTXVo3gc/qiFNjJ6n0Z9Xb1Q9YlLpxckKURfLXZ6N/HrZTCnmdvagVfyIEy5LoViW06gc9hebrc16OFLRkR+La9EAKx9uXQJe1V6/1pKBaA3eoEWPVH7eFbPdENgo5ng7itU617aKoQgO3aG/DtH8YwfHYzO2Y6zO4QjzR88Yeld3XLBj5Ezfk9aqR7WLhF3b8DinT7AHo6+sHhzaZRh4/uNXksrdUKvpNzCkFQ342HVU34jszIhgzPFoVfGspal6QXgrZX6QQ+ul0zvT1m4Uvzq1f4Wpz4e5xO4XNYnQLtwm6tRj2lCRzYOjNAY/iOvh8GLTVire6hJLEJNs70GHvwAQvuc5zTEU3BByMJ38U3+NAp6Ec+aCnnpVrN6l7fK0SGuHe34svSUYePbjx2NzPk1RS+TI82uddWB77jRjlQkyHR2WOFWzYNOoGvu6MPTN5I1Ri+y/tHBr4tT19VilDEmVKdwRd8NF9n7w2/qR1+e/Wy2vBZLY+D7s5endwDr1EKOxf4ji34HI06Nzgy6I0sfPnunUhvTNzUB7YvtWkMn83LHJC29CnvtVC/7/s1d9Tho1uGC08j+DyWsRX+O1WF7/DUbKi6JX9oS+NTHieAeItGCD9UA1EnaiHJsQkaC6UK//7I4zVaw8d8SUW3jjn4LnyVqnxoVybSCXyeWzMVPreuzedDjF0ZBBnnwqU9WRB6sgCyQmtBypc/YdhWJ4GNU31Vhs/kowjkGd7Q1nxbBLFOJeBvnAmeu1Mg6EQWpAZWgYQnfzjcWieG9c+5jw347F5sn+44u5M/0vD5fCSC/l50OBrxi1irdXxZjhIEOEFtL1Rd70BeeE4etbzlhdGHjxnyfl2jFnymc4pAUKe4x6EqfNEnGuQ+t7th1sDM5MpbzmKxKA/KYvnYP9/X2w/WH+VrDR/dXH8o0Ay+fSMDX6JbjUo9G+O/XtcKvgOvR0BXO76XlRvRAIcWRshdzvLTk5fAc3u63J5pagBbJfh+muwFvAYp9hrVua1g8kmE3OUsKx51BJetiXKfB+ZE1lBD3jEAn+OczggavZGGr+ZmD/IiNGb2gNUszRcwuy5qgb5uFNMrP7XBxXc4zAf57h5K5E7eqMPHdP2ru+HU7DKV4ctwb1N6TVXgO/1aPvR0ot/kHYJecFpSotI6vn2TUiD2HP55V12OWCfw8es7Yd+Mm2MCvk0Tw0DERT/IEh7awwo9XqwVfNmh+Nc1+Fg+9dxPtXV8v712BVpr8Y8xjP8RrhS+cPMCPJyBt2HVBFeV1vH9Ou8SNJbjvyDPfn1tdOFznNuxmoIPRhq+8PUSbJfdb7FQq50b7BvoD2Ntcpds50bqBTHyd0pb+8Dq5YZRh4+BSjbkVQyfxze3VZqAUAW+BBsOtgfq/l252guYU9042PtwWlqoNXx0i7OqURu+4L2lOofP7NMk5JqCpg5wW5+Fwp8v0Bi+fa+GY9/nm66Vai9gPvjmVeoLDu05JvveVgjf+ile0ClBOyllyRz44TFntRYw/zrPBzv0pZe8jBp8Di9Jp1Lo8UYaPrsX+cBn9yG9sgLvTq22rIWs5iNDXPoD7Plxiww+q/mNIGnuRX6Y0mxFYwI++p4Hhrzy4Ts5uxj4Naot9lYG36EpWSBsRIdBuQGtGu3cODQjFUTN6PUyvJt1Al9vdz+cfidt1OG7YX8bncxxZsOOGeHUPaK954OvRmkEX+DBPORa9LB16/RgjXZuRFuXINejUVszwVMufA7rEjBfjP2wZ0GQRjs3XH5NwL63W+Z5jQ58TnM7gxn0Rhi+5FPtSK+rW9IPzgv5GsNnOZsDvKoeBNM8TymyV/fadh6CTR/1gbq4qHFUlrPghryn55TKhS/DFT/E7W7vUxs+6/eKsdey+VeRxlvWokxrkeuJOF06gY9uVcl86lmfGvD9plv4Nk0IA15dO3LNC1+lMLs2Sm5wkd8LOligEXy54ejPTZInW+MtawcWhmFf00Nvh8mFL8UfRT43qk7jLWsr/uRILa5Ge33OW2/pHz6q8sr/nAbRG0H4XP4qhC4x+pwt4US7VkUKbh4XIZh2ivrB7g0OWqSA2qvbmI32mCoi2/UKn7S1F26capE7y4uDz30pG7s2sSJWBDmXeGrDF7iJjT6naumhhsCa79W98CF+2cWx+Wlqw5fi1sD0Lu5uPhuLRw2+M++jPZYOUQ9sfjqMgc93J9pLY2fwNIKPW4Wul3P5OU1j+OjFy7ihps33N+XC11gmQP5/jx0pWu3VTQ9BMY25WDQK8M3p5OoDvmL/LnTGtZpavvKi5tVZ7N9ogS4Rimn8UaHc6izeS7hYQAJWcPUGn6SlF0yfK4PGvA78kPeb6mHwmRqVUL1BFOxOUR+YvVEC2T7qw3fdFL2vqgSRVkUKDkzDL/Ow+jBXbfi81xdDkjN6j2JuF+yfeVMl+IJ0DF+0eSVyvczAetle3X3zo5CfRfq/986PVBs+3HIUs8XxWhUpqCtEJxhcN6fIhQ83o2xKzeJqA1/gCXR5Tm507WjA1wUjDZ/ff8TYB7Wha8RalaXK925H0OBXU/txZzcpLEtVHITuGGkt74bzM+v0Bh+9Y8PhfTYz24zMYtbQs7ylMvjSnfFD3LDd9cy2NU3gu3UBnYwoDONpXZ2lU4x+WBy/KlAbPp+fi+HArARqBhUFINmlflTga65EJ+acV2cOK1JQk43i4rc7T234cLPtph/EaAVf2JkCKIxthIzgakjwrIRo2xLY/X/BWPh+eNQN+zO3/83LWsHnui0RuWZ5GmccwmckhMZ0dGaoNqFbq3p83p+2DTwnu8uNy6t4Suvx2S9sgm4p2lOMOcjTK3x05A55XXkMeq6L2djngexECbWQOV9j+JLsm9Fv3sA2reG7u6ABg8O3RRrBR29X895QjH3AbvFhhl7hM3nnJmbCpQ92TI8YBh+9hAX5YCe1qg9fl+7hU6dIwZon3LE/l3teD9IKPseN6Ot4O5s7/uCL3or2yujFyz4fCbWCrz4VnUGsSehSuRBp4ll0a1unsA8uvFqnV/gUDXn919RS29rQHk+3tA8s3yyTVWcZl/BtGIBv51M3oDIB7UXV5Ypg59OxiuHbU6Iz+K6aomsCi2KakbJUx96MxUK9yyicwGco8Dm8JARxA7p8Jde5U6sKzOGbBFhMPT5sURk+izn1IKzvRe4ty0WkV/jo2C2qooY2qlcHuHawcVhZqvEMH52Tf03FDv2CdpfqDb6GQsw9/pqHrcfHqUAnJrx/zSHwGQp86RadaK+KKkxw8Q2BxvBZz2vBgpV9Uap26fnQDa3Y9X+uHzbqFT564fKNU1yV0KvLkMLR6YUGBR+9XS3WvBo7o3pkfoJc+AJ36wY+49fjsL24vXOjsPBFW1SgVUluNBP4DAE+j7fF0NOOPke7cUCq1ZkbyeclWEztFnA1OnOjNhmd4q9J7NA7fCbPlUJDTofiRbzURIjtonKkEOl4hO/SxpJh8P02NR7aqtHXJ9O/acThCzmCXqcqjSe3AvPZf9/C7l3e+cJVAt94h68iFH0G11rSCzZzND9s6OJbrVhM4w6KND5syP0TDnaSJHgNV6/w0VE25L1+nIOtwGwI8NFxXJaHfV1sl2Rj4QvYpRv42JnoM8bLh4vlwrdhQggIOSjS7huzCHzjHb7GDHRZA12cQJtT1kou46s8XFnL1xg+u4WNTHHSuzG9vr9N7/ApGvI2FXTA8eeKDAe+X0qwpecLwtFZcLpa864psSMC3/75MdilWMZ/jlN45kaCGzo0L4hsIvCNd/gCFkuwPzBX10o0gs//K77cqsp8di9YzW7WCL4izJq+lrJuODezZlTgM3muhBrytiP7VO3er5R75oYhwXf0lSRqjyn6pXr1WCUK307t4QvYU4R+CZWKlR42ZP1NCnb5y7bpoQS+8T65UezXjaAirOkDu3nqwWc1qwU4uT0Kn3/dMhGrDZ/3kmYspv7Lm/X+jG9oPT77D6qoMu6//+DHnmxWeNjQeITPd3OJ3MOGwo6gOyjoXQbHFyQOg89/R7HW8JUntCLXiDKrUArf5mdCsZVNnH9MJ/CNd/hcF4qYIgR39/wSTdrVgi96hwgB9O4Jji7q73H4c7Pq8D1fB0056Bq5cmrfrr6Xs+AqMJs8XwJn5pXCqTklSk9ZMzT4dk2Kg6YSdBdFYWSLTuHbaxTNTErc3c58kKDS8ZLZIeh7n32lgcBnCAuYk092IGjRxQpcFgpUgs/u5VaQctFy8rgKzoW+7SrDF7GtDbkvekjp+PeGMQGfOsdLGhp8dKw+ycI+Srm4PFdn8PlsRYsuCBo74JcJqp2r67IuA1NJpxc2Tw4h8I13+OxeFGJr8BX5dqoEX6YtWsqqnSogGrlNiD7uo37Pe3GrUvgs5zdga/OlWgv1vmWNwKcZfHTSfRrR0l51HbBnWuwAfNu1g6/oOjrRdNOJrfKB4tunh2EBs1+RQuAb7/DRCf9JikXK7wuRQvjcFvGoXhjas4veKWS2rbHj0aFqY1Y3mL2gGL5Ua7SUFV2N2XJ+PYFvJOD7r/rw+W0pVQrfoTm3QMpDl03FmLMZ+Py2aQ7frhmR1LrJPkztvVSV4aMPG8LV6EsPqB0V+NY8Tv0afbg4gU8/8NFlqWriMedsZPXAhVny4auMQmFrLugBy1kD1Vnc/9VGnSKPwhi+hS8XPqd3mrDnb1zb3qbXslSjDV+8RRPyZ4oj+FrDR5/KhvRwFheMCHx0kQK/bSWYhd59cPKtJK3gc1uXg90pQh8tqQ58l3bkotcR98AvT19WCB+uJNSpD2O1gq/oxsB73iXtAUFzB3AqRXBuSQwWvpUPu2DrIR58O0Qr+Nx3oqX7SxIbxy98Pv8WYZGK3CLBwhe8XIjfuP8Nf1gh0hwXKdJ7Ezf1woX5TVj4yiPQCrqcgi5qsqPWoOCLPIoeZFOdKtYKvsMvpGF7CeaLctSGz3+ravBtfyoWqjPQgpkVCTyt4MsNbcLOHJfEcZWmWBaqmEahEPuaXFiWpBA+3IFGVt8kaAUfpwJ9nZ3WJ8mtx4erCXh6caRW8IWcyUZ331xlj1/46OS5oXt3JZw+sH+ZNwy+C7NbobUU/cYrCepAKjDbvsaFDj46+ZFiLkbg8/+2BYupz9JmvVZgHgvweX2PWRJCLaE5PC1TY/gcvyzCbtU6MCN5xOCjt6ud/Wca9aWK9k5qc4Qawbd9SqTcYx111ZK9qhXCV5OLvqd+e3M0hm/dk95Ubxz9N5ktjZULX2UaOkwPMM7SCr6COPQLN/RczviGz+l1AYUUOsxMs2gfBl/8YfR8XHp3hfPbrdjDhugta8gMLbX16+LbzTL4zGY2ALcYfR5UHCzV+2FDYwG+MwvysbOibv8t0xg++qBxZLFvkVSjMzf8f1UdPjo37VQ761YV+JxWZMFIN7o3tWFisFz4krzY6M9qHEdj+M4ticXex/YXA+XCF22H9phvZ7VoDN+6qW5YfC2WR+sVvsWss216hY/esXHzcDsWKbe/8xn4HBa0YXFMPiuRe8qaxSwOtJSgzxBLr7TL4Lu+Dy1lRe+Ldfhbo0HCRx8vWZ+DTjqxk0XMuRvqwmf6Sib2+V7s+Tq9wLf3uRvUMY+dOoEvw78B9NEsliTIhc9xdQp2QvDoO1EawVdyE6243VwlUni85KnPorD3ferzSI3gCzNDn3fSkzirnnLSK3xLWGc26R0+ukgBXawAWTgc2sXAl+eOrvsT1vWB9YstCs/VDfyOh32T/Ja1gPUrTdDOQ4fDieeEo3Kg+FiB78pufC8p0rhOLfgOTE0FdooQO8w9szBLI/gCtpWpBR+9Xc1tTb7W8G195hp1jCP6JZoZ2ECt68sD72HJBe8tueA1LDlDks3Ekwq/ES1acNP5tlz4Nk8JZiZB7m71RQLYODlALfg8t6djX4sQkzyF8NHl57ls9L1pq5fAxhleasFn8ulV7GLwxEvl+j5Xt+g9lvGDeoePTsgKMfZZW9x+CXZhcvgGkdIDxelURHZgZoG7IcsZHTqLGnrBYm69SvBZvlIL2R4i6iyMHqoicjdkOAnBfH71PQ+f8XM5IKjvwtSao7ZlHa+DA5OVw3dsbgaUxwmwH6ycwBYZevqAj05JbKtW8Nl8jUfi+JvxTEHS32d0VZvVHTxQPMYGrdFHT2D8PCEQC9/aR/0g4nwJ9l4qU1tgx5wrKsHnvSsDejHPP5mZ5el+CuGjc3FjIvYe6ov5sP0lf5XgO78sivr7uvGluhb46hW+xawzHw2cqTsK8NGpiupWaThQl9yt9EDxQfhc/sFldl/0yylmMLSFbWxl9usqg49GT1iHfvO2VVHrBedV39Pw0XH/rkLua1+bKQaPleVwZEYGAp/Jy1lw9VA1deoZ/n2UtHZTx0qmawxf4HbN4DvxlyTskFtV+JLd0bOBuVUS2YFDmsJn9tkt7P2c+yReLnx0r6+lWoL9c/Th4mGnCmH/61cR+H5+xhcsl8VDebL84rZeO9MVruMbhG/lI65QmsDBXoPeixx6Ng+2zfdF4Fv+sCMceTcEMq6w8Z9HurTXqWwZevqA70vWuSDWYBst+DzfFWAXJw+Fiu55eH/MVxk+ukhBmjVaqBTBNLWT2aurCnx0T09eS7MT3PPwHZyUBXFnGxV++dBl3xsLpVARL4Tb1DPAlsoOuT/Mg89tHL4opLBL0jt89F7dayerNIJv65MRIG5Be8AxF6q0hm/jxMvUhAb6JRFrVyEXPjonFl2nTq5TXKBDyO2A2nweNQvbAk3lQqYKjKKWHlRNLW9xVwk+OptnXoKWGrHCa7bWSaA0iQP5MfVQmcEFqaBL4f+fRx0p+d0j9vqEr+s/rDNzRx0+ukhBpq3iisP0Ht0C7w5M2pnkI5FCaUiHXPAGf93jk2ZZWSpl8NHDW3mNW9o1LuA7OCkTbpg1KsRM1UYfL+nybTG1mDlJO/h2aA7frikx0FIlVRs+y8/w5wKbfZKkNXx0Hb5UX7Q3yW9oH/KcD4WPzplP4ihIukEXLSO4Bn583FPpzo2h8K14yBl2vBwAjeUCndxDdkQN/DCRntCw1Sd8JqyhbTThc3iFjy1AMJIt30cyrB6fMvh4bAXwFY8f+A5Q8V5dCSKO5h+wmgwRnH8nh0FvNOGjt6vZLc1SG754e3QJibi1CzZPvKoT+BxW4mE9+X6cQvh+fNQX9r0WTj3ba9X8C4kalvrsyaSe+6m2V/du+JZT+WmKJ9zyrND480ovZfE9lAbfPUyv6bPVJ3xNn7KsJowZ+Oh9ujG7JHoBr/9OVRjb1xvVgi/zovyhbrIVXyl8vivQBZvi5h6dwpflhR44nubSojZ8dI4ZZTMTG4KGLpVf29osMVxaVw57Jw1sW1MXvppM3U1uDC1LlR2MPpsqvyUfPl4duqsnxatOhp628G199gp2HVukealS+H78oy+sfcwPHFYlM5MbqjYJtV7wmmUxbJsdqFaRAhx8yx+6yOTIP0OpZ3fV1KRJn0r30C7qhijbAtg8x4tZxEyjp0/4qGd737PubqMNn7URD5rzevSCX/xxAVKBWRl85vNrmYkMpLdX0gXn57CVwnfGqAIC1zZC8Prf47a4VqfwWSwsBf911cNy/s/FGsE3uGWNntG1/agIrhnXQqYPl3m+R092sFNFUBbDh2QnDgRtr4LTb2QP26urCXxm72aBx5pi8FhdxMT9hyI4OCtBa/joKi0XV+SAy6pcWUz/ligXPusv0+DiD9l3kgVOKzNhz8xoncFHx3RRHNhTPb/fkwKH/xKlEnwDGVjDt3PuFXDZmAbR1qWQF9kAZYnNcDuzFYpimyD5EhsCj+TCqY+jqWGtt0bVWRTBN7iA+acpHmC1Io6a4MiFzLBqKL7ZyCxwpp/zJftVgr9xBph+Fg4rH3OS7dwYBfhSWCy4b8zBRydgqVD+JIeOGu92D1gYNagN3+k7+KXZCxjs6OEt3dMbQE/5chbTaeVgIksZkxNTy3QKH50jU/KGhAKPjhbwaVqkQBP4BrPzyfghuaE1fHS2PhF1J5FMtjBR/1xdXcGn6pkbyuAb6bJUqsCnyZY1PcPXv4R19i0Wro0F+Ojtaj4fC8B3sZCKQJZLi/lw6T+D4YGPLG1MvAfz+WBa76RFFq/PueD1GRccFnKwZ26M9AJmAh+Bj8A3SvDdf86NJa+NFfhUPVdX2XIWdQ8bIvAR+Ah84xI+8Res09MIfAQ+Ah+Bz2Dg+4pltpelqBH4CHwEPgLfOIOvajXL+BECH4GPwEfgMxz4WOZfspQ1Ah+Bj8BH4BtH8MWyVGkEPgIfgY/AN07g613CMnuVwEfgI/AR+AwGvi/vN7diqdoIfAQ+Ah+BbxzAx/uKZf00gY/AR+Aj8BkOfCzzTSx1GoGPwEfgI/Dd2/CZDZSTJ/AR+Ah8BD5Dge9LltlHLHUbgY/AR+Aj8N2z8N1nEcTSpBH4CHwEPgLfPQpf19csy7kEPgIfgY/AZ0jwmbA0bQQ+Ah+Bj8B3D8LXtOLucvIEPgIfgY/AN67he8Dye5Y2jcBH4CPwEfjuKfgesMSXk1ej/T+lAG2U9Fx8xAAAAABJRU5ErkJggg==";
+
+		await using var stream = new MemoryStream(Convert.FromBase64String(imgBase64));
+		await sut.Upload(stream, "sample-image.png", "image/png", CancellationToken.None);
+		stream.Close();
+
+		blobStorageServiceMock.Verify(x => x.UploadTempFileAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+		dbContextMock.Verify(x => x.Set<Image>().AddAsync(It.IsAny<Image>(), It.IsAny<CancellationToken>()));
+		dbContextMock.Verify(x => x.SaveEntitiesAsync(It.IsAny<CancellationToken>()));
+	}
+
+	[Fact(DisplayName = "Uploading a text file uploads a document succeeds")]
+	public async Task UploadingTextFileUploadsDocumentSucceeds()
+	{
+		var dbContextMock = new Mock<AppDbContext>();
+		var documentDbSetMock = new List<Document>().AsQueryable().BuildMockDbSet();
+		dbContextMock.Setup(x => x.Set<Document>())
+					 .Returns(documentDbSetMock.Object);
+		var blobStorageServiceMock = new Mock<IBlobStorageService>();
+
+		var sut = new FileService(dbContextMock.Object, blobStorageServiceMock.Object);
+
+		const string txtBase64 = "TW9uYWNvIFVuaXQgVGVzdCBGaWxlIGZvciBVcGxvYWQgZG9jdW1lbnQgc3VjY2VlZHMu";
+
+		await using var stream = new MemoryStream(Convert.FromBase64String(txtBase64));
+		await sut.Upload(stream, "sample-text-file.txt", "text/plain", CancellationToken.None);
+		stream.Close();
+
+		blobStorageServiceMock.Verify(x => x.UploadTempFileAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+		dbContextMock.Verify(x => x.Set<Document>().AddAsync(It.IsAny<Document>(), It.IsAny<CancellationToken>()));
 		dbContextMock.Verify(x => x.SaveEntitiesAsync(It.IsAny<CancellationToken>()));
 	}
 }

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/CompanyDto.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/CompanyDto.cs
@@ -3,9 +3,9 @@
 public class CompanyDto
 {
 	public Guid Id { get; set; }
-	public string Name { get; set; }
-	public string Email { get; set; }
-	public string WebSiteUrl { get; set; }
+	public string Name { get; set; } = string.Empty;
+	public string Email { get; set; } = string.Empty;
+	public string WebSiteUrl { get; set; } = string.Empty;
 	public string? Street { get; set; }
 	public string? City { get; set; }
 	public string? County { get; set; }

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/CountryDto.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/CountryDto.cs
@@ -3,5 +3,5 @@
 public class CountryDto
 {
 	public Guid Id { get; set; }
-	public string Name { get; set; }
+	public string Name { get; set; } = string.Empty;
 }

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/Extensions/CompanyExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/Extensions/CompanyExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Monaco.Template.Backend.Application.DTOs.Extensions;
-using Monaco.Template.Backend.Application.Features.Company.Commands;
+﻿using Monaco.Template.Backend.Application.Features.Company.Commands;
 using Monaco.Template.Backend.Domain.Model;
 using System.Linq.Expressions;
 

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/Extensions/CountryExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/Extensions/CountryExtensions.cs
@@ -5,18 +5,14 @@ namespace Monaco.Template.Backend.Application.DTOs.Extensions;
 
 public static class CountryExtensions
 {
-	public static CountryDto? Map(this Country? value)
-	{
-		if (value == null)
-			return null;
-
-		var dto = new CountryDto
-		{
-			Id = value.Id,
-			Name = value.Name
-		};
-		return dto;
-	}
+	public static CountryDto? Map(this Country? value) =>
+		value is null
+			? null
+			: new()
+			{
+				Id = value.Id,
+				Name = value.Name
+			};
 
 	public static Dictionary<string, Expression<Func<Country, object>>> GetMappedFields() =>
 		new()

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/Extensions/FileExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/Extensions/FileExtensions.cs
@@ -7,44 +7,38 @@ namespace Monaco.Template.Backend.Application.DTOs.Extensions;
 
 public static class FileExtensions
 {
-	public static FileDto? Map(this File? value)
-	{
-		if (value == null)
-			return null;
+	public static FileDto? Map(this File? value) =>
+		value is null
+			? null
+			: new()
+			{
+				Id = value.Id,
+				Name = value.Name,
+				Extension = value.Extension,
+				ContentType = value.ContentType,
+				Size = value.Size,
+				UploadedOn = value.UploadedOn,
+				IsTemp = value.IsTemp
+			};
 
-		return new FileDto
-		{
-			Id = value.Id,
-			Name = value.Name,
-			Extension = value.Extension,
-			ContentType = value.ContentType,
-			Size = value.Size,
-			UploadedOn = value.UploadedOn,
-			IsTemp = value.IsTemp
-		};
-	}
-
-	public static ImageDto? Map(this Image? value)
-	{
-		if (value == null)
-			return null;
-
-		return new ImageDto
-		{
-			DateTaken = value.DateTaken,
-			Width = value.Width,
-			Height = value.Height,
-			ThumbnailId = value.ThumbnailId,
-			Thumbnail = value.ThumbnailId.HasValue ? value.Thumbnail.Map() : null,
-			Id = value.Id,
-			Name = value.Name,
-			Extension = value.Extension,
-			ContentType = value.ContentType,
-			Size = value.Size,
-			UploadedOn = value.UploadedOn,
-			IsTemp = value.IsTemp
-		};
-	}
+	public static ImageDto? Map(this Image? value) =>
+		value is null
+			? null
+			: new()
+			{
+				DateTaken = value.DateTaken,
+				Width = value.Width,
+				Height = value.Height,
+				ThumbnailId = value.ThumbnailId,
+				Thumbnail = value.ThumbnailId.HasValue ? value.Thumbnail.Map() : null,
+				Id = value.Id,
+				Name = value.Name,
+				Extension = value.Extension,
+				ContentType = value.ContentType,
+				Size = value.Size,
+				UploadedOn = value.UploadedOn,
+				IsTemp = value.IsTemp
+			};
 
 	public static File Map(this FileCreateCommand value, Guid id, FileTypeEnum fileType) =>
 		fileType switch

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/FileDownloadDto.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/FileDownloadDto.cs
@@ -3,6 +3,6 @@
 public class FileDownloadDto
 {
 	public Stream FileContent { get; set; }
-	public string FileName { get; set; }
-	public string ContentType { get; set; }
+	public string FileName { get; set; } = string.Empty;
+	public string ContentType { get; set; } = string.Empty;
 }

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/FileDto.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DTOs/FileDto.cs
@@ -3,9 +3,9 @@
 public class FileDto
 {
 	public Guid Id { get; set; }
-	public string Name { get; set; }
-	public string Extension { get; set; }
-	public string ContentType { get; set; }
+	public string Name { get; set; } = string.Empty;
+	public string Extension { get; set; } = string.Empty;
+	public string ContentType { get; set; } = string.Empty;
 	public long Size { get; set; }
 	public DateTime UploadedOn { get; set; }
 	public bool IsTemp { get; set; }

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Monaco.Template.Backend.Application.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Monaco.Template.Backend.Application.csproj
@@ -15,9 +15,9 @@
 	<!--#if (filesSupport)-->
     <PackageReference Include="ExifLibNet" Version="2.1.4" />
 	<!--#endif-->
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1" />
     <!--#if (massTransitIntegration)-->
-    <PackageReference Include="MassTransit" Version="8.0.12" />
+    <PackageReference Include="MassTransit" Version="8.0.13" />
     <!--#endif-->
 	<!--#if (filesSupport)-->
     <PackageReference Include="SkiaSharp" Version="2.88.3" />

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Api.Application/MediatorExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Api.Application/MediatorExtensions.cs
@@ -18,15 +18,13 @@ public static class MediatorExtensions
 	/// <param name="mediator"></param>
 	/// <param name="query"></param>
 	/// <returns></returns>
-	public static async Task<ActionResult<TResult>> ExecuteQueryAsync<TResult>(this IMediator mediator,
-																			   QueryBase<TResult> query)
+	public static async Task<ActionResult<TResult>> ExecuteQueryAsync<TResult>(this IMediator mediator, QueryBase<TResult> query)
 	{
 		var result = await mediator.Send(query);
 
-		if (result == null)
-			return new NotFoundResult();
-
-		return new OkObjectResult(result);
+		return result is null
+			? new NotFoundResult()
+			: new OkObjectResult(result);
 	}
 
 	/// <summary>
@@ -36,15 +34,13 @@ public static class MediatorExtensions
 	/// <param name="mediator"></param>
 	/// <param name="query"></param>
 	/// <returns></returns>
-	public static async Task<ActionResult<Page<TResult>>> ExecuteQueryAsync<TResult>(this IMediator mediator,
-																					 QueryPagedBase<TResult> query)
+	public static async Task<ActionResult<Page<TResult>>> ExecuteQueryAsync<TResult>(this IMediator mediator, QueryPagedBase<TResult> query)
 	{
 		var result = await mediator.Send(query);
 
-		if (result == null)
-			return new NotFoundResult();
-
-		return new OkObjectResult(result);
+		return result is null
+			? new NotFoundResult()
+			: new OkObjectResult(result);
 	}
 
 	/// <summary>
@@ -54,15 +50,13 @@ public static class MediatorExtensions
 	/// <param name="mediator"></param>
 	/// <param name="query"></param>
 	/// <returns></returns>
-	public static async Task<ActionResult<TResult>> ExecuteQueryAsync<TResult>(this IMediator mediator,
-																			   QueryByIdBase<TResult> query)
+	public static async Task<ActionResult<TResult>> ExecuteQueryAsync<TResult>(this IMediator mediator, QueryByIdBase<TResult> query)
 	{
-		var item = await mediator.Send(query);
+		var result = await mediator.Send(query);
 
-		if (item == null)
-			return new NotFoundResult();
-
-		return new OkObjectResult(item);
+		return result is null
+			? new NotFoundResult()
+			: new OkObjectResult(result);
 	}
 
 	/// <summary>

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Api.Application/Monaco.Template.Backend.Common.Api.Application.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Api.Application/Monaco.Template.Backend.Common.Api.Application.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
-    <PackageReference Include="MediatR" Version="12.0.0" />
+    <PackageReference Include="MediatR" Version="12.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
   </ItemGroup>

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Api/Auth/AuthExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Api/Auth/AuthExtensions.cs
@@ -12,10 +12,10 @@ public static class AuthExtensions
 
 	public static IServiceCollection AddAuthorizationWithPolicies(this IServiceCollection services, List<string> scopes) =>
 		services.AddAuthorization(cfg =>
-								  {  //DefaultPolicy will require at least authenticated user by default
+								  {   // DefaultPolicy will require at least authenticated user by default
 									  cfg.DefaultPolicy = new AuthorizationPolicyBuilder(JwtBearerDefaults.AuthenticationScheme)
 														  .RequireAuthenticatedUser().Build();
-									  //Register all listed scopes as policies requiring the existance of such scope in User claims
+									  // Register all listed scopes as policies requiring the existence of such scope in User claims
 									  scopes.ForEach(s => cfg.AddPolicy(s, p => p.RequireScope(s)));
 								  });
 
@@ -23,9 +23,9 @@ public static class AuthExtensions
 																   string authority,
 																   string audience,
 																   bool requireHttpsMetadata) =>
-		services.AddTransient<IClaimsTransformation, ScopeClaimsTransformation>() //Add transformer to map scopes correctly in ClaimsPrincipal/Identity
+		services.AddTransient<IClaimsTransformation, ScopeClaimsTransformation>() // Add transformer to map scopes correctly in ClaimsPrincipal/Identity
 				.AddAuthentication()
-				.AddJwtBearer(options => //Configure validation settings for JWT bearer
+				.AddJwtBearer(options => // Configure validation settings for JWT bearer
 							  {
 								  options.Authority = authority;
 								  options.Audience = audience;

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Commands/Behaviors/CommandValidationBehavior.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Commands/Behaviors/CommandValidationBehavior.cs
@@ -55,7 +55,7 @@ public class CommandValidationBehavior<TCommand, TResult> : IPipelineBehavior<TC
 }
 
 /// <summary>
-/// Behavior to validate the existance of the entity represented by the Command Id.
+/// Behavior to validate the existence of the entity represented by the Command Id.
 /// </summary>
 /// <typeparam name="TCommand">The type of the Command to process</typeparam>
 public class CommandValidationExistsBehavior<TCommand> : IPipelineBehavior<TCommand, ICommandResult> where TCommand : CommandBase
@@ -78,7 +78,7 @@ public class CommandValidationExistsBehavior<TCommand> : IPipelineBehavior<TComm
 }
 
 /// <summary>
-/// Behavior to validate the existance of the entity represented by the Command Id.
+/// Behavior to validate the existence of the entity represented by the Command Id.
 /// </summary>
 /// <typeparam name="TCommand">The type of the Command to process</typeparam>
 /// <typeparam name="TResult">The type of data to return along with the CommandResult</typeparam>

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Monaco.Template.Backend.Common.Application.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Monaco.Template.Backend.Common.Application.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.5.0" />
+    <PackageReference Include="FluentValidation" Version="11.5.1" />
     <PackageReference Include="Polly" Version="7.2.3" />
   </ItemGroup>
 

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Validators/Extensions/ValidatorsExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Validators/Extensions/ValidatorsExtensions.cs
@@ -13,11 +13,13 @@ public static class ValidatorsExtensions
 
 	public static void CheckIfExists<TCommand, TEntity>(this AbstractValidator<TCommand> validator, BaseDbContext dbContext) where TCommand : CommandBase
 																															 where TEntity : Entity =>
-		validator.RuleSet(ExistsRulesetName, () => validator.RuleFor(x => x.Id).MustExistAsync<TCommand, TEntity>(dbContext));
+		validator.RuleSet(ExistsRulesetName, () => validator.RuleFor(x => x.Id)
+															.MustExistAsync<TCommand, TEntity>(dbContext));
 
 	public static void CheckIfExists<TCommand, TEntity, TCommandResult>(this AbstractValidator<TCommand> validator, BaseDbContext dbContext) where TCommand : CommandBase<TCommandResult>
 																																			 where TEntity : Entity =>
-		validator.RuleSet(ExistsRulesetName, () => validator.RuleFor(x => x.Id).MustExistAsync<TCommand, TEntity, TCommandResult>(dbContext));
+		validator.RuleSet(ExistsRulesetName, () => validator.RuleFor(x => x.Id)
+															.MustExistAsync<TCommand, TEntity, TCommandResult>(dbContext));
 
 	public static void CheckIfExists<TCommand>(this AbstractValidator<TCommand> validator,
 											   Func<Guid, CancellationToken, Task<bool>> predicate) where TCommand : CommandBase =>
@@ -45,9 +47,9 @@ public static class ValidatorsExtensions
 		validator.RuleSet(ExistsRulesetName, () => validator.RuleFor(selector)
 															.MustAsync(predicate));
 
-	public static void CheckIfExists<TComomand, TPropertyType>(this AbstractValidator<TComomand> validator,
-															   Expression<Func<TComomand, TPropertyType>> selector,
-															   Func<TComomand, TPropertyType, CancellationToken, Task<bool>> predicate) where TComomand : CommandBase =>
+	public static void CheckIfExists<TCommand, TPropertyType>(this AbstractValidator<TCommand> validator,
+															   Expression<Func<TCommand, TPropertyType>> selector,
+															   Func<TCommand, TPropertyType, CancellationToken, Task<bool>> predicate) where TCommand : CommandBase =>
 		validator.RuleSet(ExistsRulesetName, () => validator.RuleFor(selector)
 															.MustAsync(predicate));
 

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.BlobStorage.Tests/BlobStorageServiceTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.BlobStorage.Tests/BlobStorageServiceTests.cs
@@ -1,0 +1,51 @@
+﻿using Azure.Storage.Blobs;
+using FluentAssertions;
+using Moq;
+using Xunit;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Monaco.Template.Backend.Common.BlobStorage.Tests;
+
+[ExcludeFromCodeCoverage]
+[Trait("Common Application Services", "Blob Storage Service")]
+public class BlobStorageServiceTests
+{
+	private readonly Mock<BlobServiceClient> _blobServiceClientMock;
+	private readonly BlobStorageService _blobStorageService;
+
+	public BlobStorageServiceTests()
+	{
+		_blobServiceClientMock = new Mock<BlobServiceClient>();
+		_blobStorageService = new(_blobServiceClientMock.Object, It.IsAny<string>());
+	}
+
+	[Theory(DisplayName = "Get file type succeeds")]
+	[MemberData(nameof(GetFileTypeTestData))]
+	public void GetFileTypeSucceeds(string fileExtension, FileTypeEnum expected)
+	{
+		var fileType = _blobStorageService.GetFileType(fileExtension);
+		fileType.Should().Be(expected);
+	}
+
+	public static IEnumerable<object[]> GetFileTypeTestData =>
+		new List<object[]>
+		{
+			new object[] { ".doc", FileTypeEnum.Document },
+			new object[] { ".docx", FileTypeEnum.Document },
+			new object[] { ".pdf", FileTypeEnum.Document },
+			new object[] { ".rtf", FileTypeEnum.Document },
+			new object[] { ".txt", FileTypeEnum.Document },
+			new object[] { ".xls", FileTypeEnum.Document },
+			new object[] { ".xlsx", FileTypeEnum.Document },
+			new object[] { ".xlsm", FileTypeEnum.Document },
+			new object[] { ".jpg", FileTypeEnum.Image },
+			new object[] { ".jpeg", FileTypeEnum.Image },
+			new object[] { ".png", FileTypeEnum.Image },
+			new object[] { ".bmp", FileTypeEnum.Image },
+			new object[] { ".gif", FileTypeEnum.Image },
+			new object[] { ".tif", FileTypeEnum.Image },
+			new object[] { ".tiff", FileTypeEnum.Image },
+			new object[] { ".other", FileTypeEnum.Others }
+		};
+}

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.BlobStorage.Tests/Monaco.Template.Backend.Common.BlobStorage.Tests.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.BlobStorage.Tests/Monaco.Template.Backend.Common.BlobStorage.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="6.10.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+		<PackageReference Include="MockQueryable.Moq" Version="7.0.0" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Monaco.Template.Backend.Common.BlobStorage\Monaco.Template.Backend.Common.BlobStorage.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.BlobStorage/BlobStorageService.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.BlobStorage/BlobStorageService.cs
@@ -61,15 +61,13 @@ public class BlobStorageService : IBlobStorageService
 		return destId;
 	}
 
-	public FileTypeEnum GetFileType(string fileExtension)
-	{
-		return fileExtension.Trim('.') switch
+	public FileTypeEnum GetFileType(string fileExtension) =>
+		fileExtension.Trim('.').ToLower() switch
 		{
 			"doc" or "docx" or "pdf" or "rtf" or "txt" or "xls" or "xlsx" or "xlsm" => FileTypeEnum.Document,
-			"jpg" or "jpeg" or "png" or "bmp" or "gif" or "tiff" => FileTypeEnum.Image,
+			"jpg" or "jpeg" or "png" or "bmp" or "gif" or "tif" or "tiff" => FileTypeEnum.Image,
 			_ => FileTypeEnum.Others,
 		};
-	}
 
 	private static string GetTempPath(string blobFileName) => $"temp/{blobFileName}";
 
@@ -78,10 +76,10 @@ public class BlobStorageService : IBlobStorageService
 	private Dictionary<string, string> GetMetadata(string fileName, string contentType) =>
 		new()
 		{
-			{ BlobMetadata.Name, HttpUtility.UrlEncode(Path.GetFileNameWithoutExtension(fileName)) },
-			{ BlobMetadata.Extension, HttpUtility.UrlEncode(Path.GetExtension(fileName)) },
-			{ BlobMetadata.ContentType, contentType },
-			{ BlobMetadata.UploadedOn, DateTime.UtcNow.ToString("O") },
-			{ BlobMetadata.FileType, GetFileType(Path.GetExtension(fileName)).ToString()}
+			[BlobMetadata.Name] = HttpUtility.UrlEncode(Path.GetFileNameWithoutExtension(fileName)),
+			[BlobMetadata.Extension] = HttpUtility.UrlEncode(Path.GetExtension(fileName)),
+			[BlobMetadata.ContentType] = contentType,
+			[BlobMetadata.UploadedOn] = DateTime.UtcNow.ToString("O"),
+			[BlobMetadata.FileType] = GetFileType(Path.GetExtension(fileName)).ToString()
 		};
 }

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.BlobStorage/Monaco.Template.Backend.Common.BlobStorage.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.BlobStorage/Monaco.Template.Backend.Common.BlobStorage.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.15.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
   </ItemGroup>
 

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/DomainEventTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/DomainEventTests.cs
@@ -8,12 +8,12 @@ using Xunit;
 namespace Monaco.Template.Backend.Common.Domain.Tests;
 
 [ExcludeFromCodeCoverage]
+[Trait("Common Domain Entities", "Domain Event Entity")]
 public class DomainEventTests
 {
-	[Trait("Common Domain Entities", "Domain Event Entity")]
 	[Theory(DisplayName = "New domain event succeeds")]
 	[AnonymousData]
-	public void NewEntityWithoutParametersSucceeds(DomainEvent sut)
+	public void NewDomainEventWithoutParametersSucceeds(DomainEvent sut)
 	{
 		sut.DateOccurred.Should().BeCloseTo(DateTime.UtcNow, new TimeSpan(0, 0, 5));
 	}

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/EntityTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/EntityTests.cs
@@ -12,9 +12,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Common.Domain.Tests;
 
 [ExcludeFromCodeCoverage]
+[Trait("Common Domain Entities", "Base Entity")]
 public class EntityTests
 {
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "New entity without parameters succeeds")]
 	[AnonymousData]
 	public void NewEntityWithoutParametersSucceeds(Entity sut)
@@ -23,7 +23,6 @@ public class EntityTests
 		sut.DomainEvents.Should().BeEmpty();
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "New entity with parameters succeeds")]
 	[AnonymousData]
 	public void NewEntityWithParametersSucceeds(Guid id)
@@ -37,7 +36,6 @@ public class EntityTests
 		sut.DomainEvents.Should().BeEmpty();
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Add Domain Event succeeds")]
 	[AnonymousData]
 	public void AddDomainEventSucceeds(Entity sut, DomainEvent domainEvent)
@@ -47,7 +45,6 @@ public class EntityTests
 		sut.DomainEvents.Should().HaveCount(1).And.Contain(domainEvent);
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Add duplicated domain event allowing duplicates succeeds")]
 	[AnonymousData]
 	public void AddDuplicatedDomainEventAllowingDuplicatesSucceeds(Entity sut, DomainEvent domainEvent)
@@ -58,7 +55,6 @@ public class EntityTests
 		sut.DomainEvents.Should().HaveCount(2).And.Contain(new[] { domainEvent, domainEvent });
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Add duplicated domain event not allowing duplicates adds only one")]
 	[AnonymousData]
 	public void AddDuplicatedDomainEventNotAllowingDuplicatesAddsOnlyOne(Entity sut, DomainEvent domainEvent)
@@ -69,7 +65,6 @@ public class EntityTests
 		sut.DomainEvents.Should().HaveCount(1).And.Contain(domainEvent);
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Add duplicated type of domain event not allowing duplicates adds only one")]
 	[AnonymousData]
 	public void AddDuplicatedTypeOfDomainEventNotAllowingDuplicatesAddsOnlyOne(Entity sut, DomainEvent domainEvent1, DomainEvent domainEvent2)
@@ -80,7 +75,6 @@ public class EntityTests
 		sut.DomainEvents.Should().HaveCount(1).And.Contain(domainEvent1);
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Remove Domain Event succeeds")]
 	[AnonymousData]
 	public void RemoveDomainEventSucceeds(Entity sut, List<DomainEvent> domainEvents)
@@ -92,7 +86,6 @@ public class EntityTests
 		sut.DomainEvents.Should().HaveCount(2).And.Contain(new[] { domainEvents[1], domainEvents[2] });
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Remove Domain Event succeeds")]
 	[AnonymousData]
 	public void RemoveNonExistingDomainEventSucceeds(Entity sut, List<DomainEvent> domainEvents)
@@ -107,7 +100,6 @@ public class EntityTests
 		sut.DomainEvents.Should().HaveCount(2).And.Contain(new[] { domainEvents[0], domainEvents[1] });
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Clear Domain Events succeeds")]
 	[AnonymousData]
 	public void ClearDomainEventsSucceeds(Entity sut, List<DomainEvent> domainEvents)
@@ -121,7 +113,6 @@ public class EntityTests
 		sut.DomainEvents.Should().BeEmpty();
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Entity instance equals (method) itself succeeds")]
 	[AnonymousData]
 	public void EntityInstanceEqualsMethodItselfSucceeds(Entity sut)
@@ -129,7 +120,6 @@ public class EntityTests
 		sut.Equals(sut).Should().BeTrue();
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Entity instance equals (method) another instance same Id as same succeeds")]
 	[AnonymousData]
 	public void EntityInstanceEqualsMethodAnotherInstanceSameIdAsSameSucceeds(Guid id)
@@ -143,7 +133,6 @@ public class EntityTests
 		sut.Equals(instance).Should().BeTrue();
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Entity instance equals (method) another instance as different succeeds")]
 	[AnonymousData]
 	public void EntityInstanceEqualsMethodAnotherInstanceAsDifferentSucceeds(Entity sut, Entity instance)
@@ -151,7 +140,6 @@ public class EntityTests
 		sut.Equals(instance).Should().BeFalse();
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Entity instance equals (method) another different object as different succeeds ")]
 	[AnonymousData]
 	public void EntityInstanceEqualsMethodAnotherDifferentObjectAsDifferentSucceeds(Entity sut, object instance)
@@ -159,7 +147,6 @@ public class EntityTests
 		sut.Equals(instance).Should().BeFalse();
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Entity instance equals (method) another different not proxy object as different succeeds ")]
 	[AnonymousData]
 	public void EntityInstanceEqualsMethodAnotherDifferentNotProxyObjectAsDifferentSucceeds(Entity sut)
@@ -167,7 +154,6 @@ public class EntityTests
 		sut.Equals(new object()).Should().BeFalse();
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Entity instance equals (operator) itself succeeds")]
 	[AnonymousData]
 	public void EntityInstanceEqualsOperatorItselfSucceeds(Entity sut)
@@ -178,7 +164,6 @@ public class EntityTests
 #pragma warning restore CS1718 // Comparison made to same variable
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Entity instance equals (operator) as different succeeds")]
 	[AnonymousData]
 	public void EntityInstanceEqualsOperatorNullAsDifferentSucceeds(Entity sut)
@@ -186,14 +171,12 @@ public class EntityTests
 		(sut == null).Should().BeFalse();
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Fact(DisplayName = "Entity instance null equals (operator) null as same succeeds")]
 	public void EntityInstanceNullEqualsOperatorNullAsSameSucceeds()
 	{
 		(null as Entity == null).Should().BeTrue();
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Entity instance equals (operator) null as different succeeds")]
 	[AnonymousData]
 	public void EntityInstanceNotEqualsOperatorNullAsDifferentSucceeds(Entity? sut)
@@ -201,7 +184,6 @@ public class EntityTests
 		(sut != null).Should().BeTrue();
 	}
 
-	[Trait("Common Domain Entities", "Base Entity")]
 	[Theory(DisplayName = "Get Entity hash code succeeds")]
 	[AnonymousData]
 	public void EntityGetHashCodeSucceeds(Entity sut)

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/EnumerationTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/EnumerationTests.cs
@@ -10,9 +10,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Common.Domain.Tests;
 
 [ExcludeFromCodeCoverage]
+[Trait("Common Domain Entities", "Enumeration Entity")]
 public class EnumerationTests
 {
-	[Trait("Common Domain Entities", "Enumeration Entity")]
 	[Theory(DisplayName = "New enumeration instance succeeds")]
 	[AnonymousData]
 	public void NewEnumerationInstanceSucceeds(Guid id, string name)
@@ -26,7 +26,6 @@ public class EnumerationTests
 		sut.Name.Should().Be(name);
 	}
 
-	[Trait("Common Domain Entities", "Enumeration Entity")]
 	[Theory(DisplayName = "Enumeration to string is name")]
 	[AnonymousData]
 	public void EnumerationToStringIsName(Guid id, string name)
@@ -39,7 +38,6 @@ public class EnumerationTests
 		sut.ToString().Should().Be(name);
 	}
 
-	[Trait("Common Domain Entities", "Enumeration Entity")]
 	[Fact(DisplayName = "Get all items from Enumeration succeeds")]
 	public void GetAllItemsFromEnumerationSucceeds()
 	{
@@ -47,7 +45,6 @@ public class EnumerationTests
 				   .Should().HaveCount(2).And.Contain(new[] { DummyEnumerationDerived.Item3, DummyEnumerationDerived.Item4 });
 	}
 
-	[Trait("Common Domain Entities", "Enumeration Entity")]
 	[Fact(DisplayName = "Get an enumeration item from its value succeeds")]
 	public void GetAnEnumerationItemFromItsValueSucceeds()
 	{
@@ -58,7 +55,6 @@ public class EnumerationTests
 		result.Should().Be(DummyEnumeration.Item1);
 	}
 
-	[Trait("Common Domain Entities", "Enumeration Entity")]
 	[Theory(DisplayName = "Get an enumeration item from invalid value fails")]
 	[AnonymousData]
 	public void GetAnEnumerationItemFromInvalidValueFails(Guid id)
@@ -68,7 +64,6 @@ public class EnumerationTests
 		action.Should().Throw<InvalidOperationException>().WithMessage($"'{id}' is not a valid value in {typeof(DummyEnumeration)}");
 	}
 
-	[Trait("Common Domain Entities", "Enumeration Entity")]
 	[Fact(DisplayName = "Get an enumeration item from its name succeeds")]
 	public void GetAnEnumerationItemFromItsNameSucceeds()
 	{
@@ -79,7 +74,6 @@ public class EnumerationTests
 		result.Should().Be(DummyEnumeration.Item1);
 	}
 
-	[Trait("Common Domain Entities", "Enumeration Entity")]
 	[Theory(DisplayName = "Get an enumeration item from invalid value fails")]
 	[AnonymousData]
 	public void GetAnEnumerationItemFromInvalidNameFails(string name)
@@ -89,7 +83,6 @@ public class EnumerationTests
 		action.Should().Throw<InvalidOperationException>().WithMessage($"'{name}' is not a valid display name in {typeof(DummyEnumeration)}");
 	}
 
-	[Trait("Common Domain Entities", "Enumeration Entity")]
 	[Fact(DisplayName = "Enumeration compare succeeds")]
 	public void EnumerationCompareSucceds()
 	{

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/Monaco.Template.Backend.Common.Domain.Tests.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/Monaco.Template.Backend.Common.Domain.Tests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/PageTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/PageTests.cs
@@ -13,7 +13,7 @@ public class PageTests
 	[Trait("Common Domain Entities", "Page Entity")]
 	[Theory(DisplayName = "Create a new page succeeds")]
 	[AnonymousData]
-	public void Create_a_new_page(List<string> results, int offset, int limit, long count)
+	public void CreateNewPageSucceeds(List<string> results, int offset, int limit, long count)
 	{
 		var sut = new Page<string>(results, offset, limit, count);
 
@@ -24,7 +24,7 @@ public class PageTests
 	[Trait("Common Domain Entities", "Pager Entity")]
 	[Theory(DisplayName = "Create a new pager succeeds")]
 	[AnonymousData]
-	public void Create_a_new_pager(int offset, int limit, long count)
+	public void CreateNewPagerSucceeds(int offset, int limit, long count)
 	{
 		var sut = new Pager(offset, limit, count);
 

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/ValueObjectTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/ValueObjectTests.cs
@@ -8,9 +8,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Common.Domain.Tests;
 
 [ExcludeFromCodeCoverage]
+[Trait("Common Domain entities", "ValueObject")]
 public class ValueObjectTests
 {
-	[Trait("Common Domain entities", "ValueObject")]
 	[Theory(DisplayName = "New ValueObject instance succeeds")]
 	[AnonymousData]
 	public void NewValueObjectInstanceSucceeds(string field1, string? field2)
@@ -21,7 +21,6 @@ public class ValueObjectTests
 		sut.Field2.Should().Be(field2);
 	}
 
-	[Trait("Common Domain entities", "ValueObject")]
 	[Theory(DisplayName = "Different ValueObject instances with same values are equal")]
 	[AnonymousData]
 	public void DifferentValueObjectInstancesWithSameValuesAreEqual(string field1, string? field2)
@@ -33,7 +32,6 @@ public class ValueObjectTests
 		val1.Equals(val2).Should().BeTrue();
 	}
 
-	[Trait("Common Domain entities", "ValueObject")]
 	[Theory(DisplayName = "Different ValueObject instances with same values are not equal")]
 	[AnonymousData]
 	public void DifferentValueObjectInstancesWithDifferentValuesAreNotEqual(string field1, string? field2, string? field3)
@@ -45,7 +43,6 @@ public class ValueObjectTests
 		val1.Equals(val2).Should().BeFalse();
 	}
 
-	[Trait("Common Domain entities", "ValueObject")]
 	[Theory(DisplayName = "Different ValueObject instances with same values are not equal")]
 	[AnonymousData]
 	public void ValueObjectComparedAgainstNullIsNotEqual(string field1, string? field2)

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain/Monaco.Template.Backend.Common.Domain.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain/Monaco.Template.Backend.Common.Domain.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR.Contracts" Version="2.0.0" />
+    <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Context/Extensions/FilterExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Context/Extensions/FilterExtensions.cs
@@ -59,13 +59,13 @@ public static class FilterExtensions
 
 		var (filterMapLower, filterList, predicate) = GetData(queryString, filterMap, defaultCondition);
 
-		foreach (var (key, values) in filterList) //and while looping through the list of valid ones to use
+		foreach (var (key, values) in filterList) // and while looping through the list of valid ones to use
 		{
-			var predicateKey = PredicateBuilder.New<T>(false); //Declare a PredicateBuilder for the current key values
+			var predicateKey = PredicateBuilder.New<T>(false); // Declare a PredicateBuilder for the current key values
 			predicateKey = values.Where(value => ValidateDataType(value, GetBodyExpression(filterMapLower[key]).Type))
-								 .Select(value => GetOperationExpression(key, filterMapLower[key], value, true)) //then generate the expresion for each value
-								 .Aggregate(predicateKey, (current, expr) => current.Or(expr)); //and chain them all with an OR operator
-			predicate = allConditions ? predicate.And(predicateKey) : predicate.Or(predicateKey); //then add the resulting expresion to the more general predicate
+								 .Select(value => GetOperationExpression(key, filterMapLower[key], value, true)) // then generate the expression for each value
+								 .Aggregate(predicateKey, (current, expr) => current.Or(expr));		// and chain them all with an OR operator
+			predicate = allConditions ? predicate.And(predicateKey) : predicate.Or(predicateKey);	// then add the resulting expression to the more general predicate
 		}
 
 		return source.Where(predicate);
@@ -78,13 +78,13 @@ public static class FilterExtensions
 				   Dictionary<string, Expression<Func<T, object>>> filterMap,
 				   bool defaultCondition)
 	{
-		//convert to Dictionary with Keys in Lowercase to ease search
+		// convert to Dictionary with Keys in Lowercase to ease search
 		var filterMapLower = filterMap.ToDictionary(x => x.Key.ToLower(), x => x.Value);
-		//convert field list to filter in a lowercase list, then filter the ones that don't exist and the null ones
+		// convert field list to filter in a lowercase list, then filter the ones that don't exist and the null ones
 		var filterList = queryString.ToDictionary(q => q.Key.ToLower(),
 												  q => q.Value.Select(v => v?.ToLower()))
 									.Where(x => filterMapLower.ContainsKey(x.Key.ToLower()));
-		var predicate = PredicateBuilder.New<T>(defaultCondition); //Generate a PredicateBuilder (True to return all by default)
+		var predicate = PredicateBuilder.New<T>(defaultCondition); // Generate a PredicateBuilder (True to return all by default)
 
 		return (filterMapLower, filterList, predicate);
 	}
@@ -94,21 +94,21 @@ public static class FilterExtensions
 
 	private static Expression<Func<T, bool>> GetOperationExpression<T>(string fieldKey, Expression<Func<T, object>> fieldMap, object? value, bool toLowerCase = false)
 	{
-		//Obtain expression Type and based on it y choose the method for the operation on the DB depending on if it's a String or any other type
+		// Obtain expression Type and based on it choose the method for the operation on the DB depending on if it's a String or any other type
 		var bodyExpression = GetBodyExpression(fieldMap);
 		var type = bodyExpression.Type;
 
-		//Create the call to the method using the selected expression, the method and the value to search. If it's a string and it´s working on an IEnumerable, first apply ToLower
+		// Create the call to the method using the selected expression, the method and the value to search. If it's a string and it´s working on an IEnumerable, first apply ToLower
 		Expression expression;
 
-		if ((value as string) is not { Length: > 0 }) //Handles comparison against null values
+		if ((value as string) is not { Length: > 0 }) // Handles comparison against null values
 			expression = Expression.Equal(type == typeof(string) || type.GetGenericTypeDefinition() == typeof(Nullable<>)
-											  ? bodyExpression                                                                //for strings
-											  : Expression.Convert(bodyExpression, typeof(Nullable<>).MakeGenericType(type)), //for all others
+											  ? bodyExpression                                                                // for strings
+											  : Expression.Convert(bodyExpression, typeof(Nullable<>).MakeGenericType(type)), // for all others
 										  Expression.Constant(null));
-		else if (type == typeof(string)) //Handles string values
+		else if (type == typeof(string)) // Handles string values
 		{
-			expression = toLowerCase //If it's needed, applies lower case to entire string to ignore casing differences
+			expression = toLowerCase // If needed, applies lower case to entire string to ignore casing differences
 							 ? Expression.Call(bodyExpression, type.GetMethod(nameof(string.ToLower), Type.EmptyTypes)!)
 							 : bodyExpression;
 
@@ -116,14 +116,14 @@ public static class FilterExtensions
 			var not = strValue is ['!', ..];
 			if (not) strValue = strValue[1..];
 
-			if (strValue is ['"', .., '"'])     //quoted strings searches as exactly the same
+			if (strValue is ['"', .., '"']) // quoted strings searches as exactly the same
 			{
 				var constExpr = Expression.Constant(Convert.ChangeType(strValue[1..^1], type));
 				expression = not
 								 ? Expression.NotEqual(expression, constExpr)
 								 : Expression.Equal(expression, constExpr);
 			}
-			else    //otherwise searches with Contains
+			else // otherwise searches with Contains
 			{
 				expression = Expression.Call(expression,
 											 type.GetMethod(nameof(string.Contains), new[] { type })!,
@@ -133,20 +133,20 @@ public static class FilterExtensions
 		}
 		else if (type.IsEnum)
 			expression = Expression.Equal(bodyExpression, Expression.Constant(Enum.Parse(type, (string.IsNullOrWhiteSpace(value?.ToString()) ? 0.ToString() : value!.ToString()) ?? 0.ToString())));
-		else if (type.IsAssignableFrom(typeof(Guid))) //Handles Guid values
+		else if (type.IsAssignableFrom(typeof(Guid))) // Handles Guid values
 			expression = value.ToString() is ['!', ..]
 							 ? Expression.NotEqual(bodyExpression, Expression.Constant(Guid.Parse(value.ToString()![1..]), type))
 							 : Expression.Equal(bodyExpression, Expression.Constant(Guid.Parse(value.ToString()!), type));
-		else if (type.IsAssignableFrom(typeof(DateTime)) && fieldKey.EndsWith("from")) //Handles DateTime values whose param name ends with From (range start)
+		else if (type.IsAssignableFrom(typeof(DateTime)) && fieldKey.EndsWith("from")) // Handles DateTime values whose param name ends with From (range start)
 			expression = Expression.GreaterThanOrEqual(bodyExpression, Expression.Constant(DateTime.Parse(value.ToString()!), type));
-		else if (type.IsAssignableFrom(typeof(DateTime)) && fieldKey.EndsWith("to")) //Handles DateTime values whose param name ends with To (range end)
+		else if (type.IsAssignableFrom(typeof(DateTime)) && fieldKey.EndsWith("to")) // Handles DateTime values whose param name ends with To (range end)
 			expression = Expression.LessThanOrEqual(bodyExpression, Expression.Constant(DateTime.Parse(value.ToString()!), type));
-		else //Handles all other generic cases (numbers, booleans, etc)
+		else // Handles all other generic cases (numbers, booleans, etc)
 			expression = value.ToString() is ['!', ..]
 							 ? Expression.NotEqual(bodyExpression, Expression.Constant(Convert.ChangeType(value.ToString()![1..], type)))
 							 : Expression.Equal(bodyExpression, Expression.Constant(Convert.ChangeType(value, type)));
 
-		//Create and return the lambda expression that represents the operation to run
+		// Create and return the lambda expression that represents the operation to run
 		return Expression.Lambda<Func<T, bool>>(expression, fieldMap.Parameters);
 	}
 

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Context/Extensions/OperationsExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Context/Extensions/OperationsExtensions.cs
@@ -13,7 +13,7 @@ public static class OperationsExtensions
 
 	public static Task<bool> ExistsAsync<T>(this DbContext dbContext,
 											Expression<Func<T, bool>> predicate,
-											CancellationToken cancellationToken) where T : class => 
+											CancellationToken cancellationToken) where T : class =>
 		dbContext.Set<T>().AnyAsync(predicate, cancellationToken);
 
 	public static async Task<T?> GetAsync<T>(this DbContext dbContext,
@@ -33,4 +33,13 @@ public static class OperationsExtensions
 									.GetMethod("Set", Type.EmptyTypes)?
 									.MakeGenericMethod(t)
 									.Invoke(context, Array.Empty<object?>())!;
+
+	public static async Task<List<T>> GetListByIdsAsync<T>(this DbContext dbContext,
+														   IEnumerable<Guid> items,
+														   CancellationToken cancellationToken) where T : Entity =>
+		items?.Any() == true
+			? await dbContext.Set<T>()
+							 .Where(x => items.Contains(x.Id))
+							 .ToListAsync(cancellationToken)
+			: new();
 }

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Monaco.Template.Backend.Common.Infrastructure.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Monaco.Template.Backend.Common.Infrastructure.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="DelegateDecompiler.EntityFrameworkCore5" Version="0.32.0" />
     <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="7.1.3" />
-    <PackageReference Include="MediatR" Version="12.0.0" />
+    <PackageReference Include="MediatR" Version="12.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Tests/Monaco.Template.Backend.Common.Tests.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Tests/Monaco.Template.Backend.Common.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/AddressTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/AddressTests.cs
@@ -7,9 +7,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Domain.Tests;
 
 [ExcludeFromCodeCoverage]
+[Trait("Core Domain Entities", "Address Entity")]
 public class AddressTests
 {
-	[Trait("Core Domain Entities", "Address Entity")]
 	[Theory(DisplayName = "New address succeeds")]
 	[AnonymousData]
 	public void NewAddressSucceeds(string? street,

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/CompanyTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/CompanyTests.cs
@@ -7,9 +7,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Domain.Tests;
 
 [ExcludeFromCodeCoverage]
+[Trait("Core Domain Entities", "Company Entity")]
 public class CompanyTests
 {
-	[Trait("Core Domain Entities", "Company Entity")]
 	[Theory(DisplayName = "New company succeeds")]
 	[AnonymousData]
 	public void NewCompanySucceeds(string name,
@@ -29,7 +29,6 @@ public class CompanyTests
 		sut.Version.Should().BeNull();
 	}
 
-	[Trait("Core Domain Entities", "Company Entity")]
 	[Theory(DisplayName = "New company succeeds")]
 	[AnonymousData]
 	public void UpdateCompanySucceeds(Company sut,

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/CountryTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/CountryTests.cs
@@ -7,9 +7,9 @@ using Xunit;
 namespace Monaco.Template.Backend.Domain.Tests;
 
 [ExcludeFromCodeCoverage]
+[Trait("Core Domain Entities", "Country Entity")]
 public class CountryTests
 {
-	[Trait("Core Domain Entities", "Country Entity")]
 	[Theory(DisplayName = "New country succeeds")]
 	[AnonymousData]
 	public void NewCountrySucceeds(string name)

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/Monaco.Template.Backend.Domain.Tests.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/Monaco.Template.Backend.Domain.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.sln
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.sln
@@ -3,7 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31808.319
 MinimumVisualStudioVersion = 10.0.40219.1
-#if (!excludeCommon)
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{1095FB23-B2A1-4FD6-BC12-433529EEA56E}"
 	ProjectSection(SolutionItems) = preProject
 		nuget.config = nuget.config
@@ -13,13 +12,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{8BFE9C
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{35484293-234F-40DA-B430-A95170EDE449}"
 EndProject
-#if (keycloakConfig)
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "KeyCloak", "KeyCloak", "{29DFBC35-3DA6-4C68-AA97-5CCE06D80917}"
 	ProjectSection(SolutionItems) = preProject
 		realm-export-template.json = realm-export-template.json
 	EndProjectSection
 EndProject
-#endif
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monaco.Template.Backend.Common.Domain.Tests", "Monaco.Template.Backend.Common.Domain.Tests\Monaco.Template.Backend.Common.Domain.Tests.csproj", "{426A6AB4-95F6-46AC-AB6D-98C4612F74E5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monaco.Template.Backend.Common.Api", "Monaco.Template.Backend.Common.Api\Monaco.Template.Backend.Common.Api.csproj", "{78120DEF-B581-4D6B-92D7-1735070ACB7F}"
@@ -36,15 +33,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monaco.Template.Backend.Com
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monaco.Template.Backend.Common.Api.Application", "Monaco.Template.Backend.Common.Api.Application\Monaco.Template.Backend.Common.Api.Application.csproj", "{F733BD0F-4C55-4E65-92E8-837191C37357}"
 EndProject
-#endif
-#if (massTransitIntegration)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monaco.Template.Backend.Common.Messaging.Messages", "Monaco.Template.Backend.Common.Messaging.Messages\Monaco.Template.Backend.Common.Messaging.Messages.csproj", "{45B82388-702E-4485-BEB5-995051DB9952}"
 EndProject
-#endif
-#if (apiGateway)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monaco.Template.Backend.Common.ApiGateway", "Monaco.Template.Backend.Common.ApiGateway\Monaco.Template.Backend.Common.ApiGateway.csproj", "{815EF0B0-5FDA-4D1E-BACE-DA7E440D5D34}"
 EndProject
-#endif
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{920A23AF-59DA-4453-B825-0549B1C04F5B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monaco.Template.Backend.Application.Tests", "Monaco.Template.Backend.Application.Tests\Monaco.Template.Backend.Application.Tests.csproj", "{E5781B96-E0CA-4762-9412-C4202E0CA08F}"
@@ -61,17 +53,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monaco.Template.Backend.App
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monaco.Template.Backend.Application.Infrastructure.Migrations", "Monaco.Template.Backend.Application.Infrastructure.Migrations\Monaco.Template.Backend.Application.Infrastructure.Migrations.csproj", "{1B80E15B-FC20-4B57-A3E5-3B6B3EBDA92F}"
 EndProject
-#if (filesSupport)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monaco.Template.Backend.Common.BlobStorage", "Monaco.Template.Backend.Common.BlobStorage\Monaco.Template.Backend.Common.BlobStorage.csproj", "{42E51D47-B82F-4A92-B1E5-CD8BE44DE6F0}"
 EndProject
-#endif
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monaco.Template.Backend.Common.BlobStorage.Tests", "Monaco.Template.Backend.Common.BlobStorage.Tests\Monaco.Template.Backend.Common.BlobStorage.Tests.csproj", "{1F3073EF-20EF-4BDB-B0DB-065034E76E76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		#if (!excludeCommon)
 		{426A6AB4-95F6-46AC-AB6D-98C4612F74E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{426A6AB4-95F6-46AC-AB6D-98C4612F74E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{426A6AB4-95F6-46AC-AB6D-98C4612F74E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -104,19 +95,14 @@ Global
 		{F733BD0F-4C55-4E65-92E8-837191C37357}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F733BD0F-4C55-4E65-92E8-837191C37357}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F733BD0F-4C55-4E65-92E8-837191C37357}.Release|Any CPU.Build.0 = Release|Any CPU
-		#endif
-		#if (massTransitIntegration)
 		{45B82388-702E-4485-BEB5-995051DB9952}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{45B82388-702E-4485-BEB5-995051DB9952}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{45B82388-702E-4485-BEB5-995051DB9952}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{45B82388-702E-4485-BEB5-995051DB9952}.Release|Any CPU.Build.0 = Release|Any CPU
-		#endif
-		#if (apiGateway)
 		{815EF0B0-5FDA-4D1E-BACE-DA7E440D5D34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{815EF0B0-5FDA-4D1E-BACE-DA7E440D5D34}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{815EF0B0-5FDA-4D1E-BACE-DA7E440D5D34}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{815EF0B0-5FDA-4D1E-BACE-DA7E440D5D34}.Release|Any CPU.Build.0 = Release|Any CPU
-		#endif
 		{E5781B96-E0CA-4762-9412-C4202E0CA08F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E5781B96-E0CA-4762-9412-C4202E0CA08F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E5781B96-E0CA-4762-9412-C4202E0CA08F}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -145,18 +131,19 @@ Global
 		{1B80E15B-FC20-4B57-A3E5-3B6B3EBDA92F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1B80E15B-FC20-4B57-A3E5-3B6B3EBDA92F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1B80E15B-FC20-4B57-A3E5-3B6B3EBDA92F}.Release|Any CPU.Build.0 = Release|Any CPU
-		#if (filesSupport)
 		{42E51D47-B82F-4A92-B1E5-CD8BE44DE6F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{42E51D47-B82F-4A92-B1E5-CD8BE44DE6F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{42E51D47-B82F-4A92-B1E5-CD8BE44DE6F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{42E51D47-B82F-4A92-B1E5-CD8BE44DE6F0}.Release|Any CPU.Build.0 = Release|Any CPU
-		#endif
+		{1F3073EF-20EF-4BDB-B0DB-065034E76E76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F3073EF-20EF-4BDB-B0DB-065034E76E76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F3073EF-20EF-4BDB-B0DB-065034E76E76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F3073EF-20EF-4BDB-B0DB-065034E76E76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		#if (!excludeCommon)
 		{35484293-234F-40DA-B430-A95170EDE449} = {8BFE9C37-2620-4156-88B8-286537954C5E}
 		{426A6AB4-95F6-46AC-AB6D-98C4612F74E5} = {35484293-234F-40DA-B430-A95170EDE449}
 		{78120DEF-B581-4D6B-92D7-1735070ACB7F} = {8BFE9C37-2620-4156-88B8-286537954C5E}
@@ -166,19 +153,12 @@ Global
 		{B82D784A-81A2-46C5-A966-B472B8FCAD46} = {8BFE9C37-2620-4156-88B8-286537954C5E}
 		{0FB378C2-9DE1-437F-8A62-774747105CE5} = {8BFE9C37-2620-4156-88B8-286537954C5E}
 		{F733BD0F-4C55-4E65-92E8-837191C37357} = {8BFE9C37-2620-4156-88B8-286537954C5E}
-		#endif
-		#if (massTransitIntegration)
 		{45B82388-702E-4485-BEB5-995051DB9952} = {8BFE9C37-2620-4156-88B8-286537954C5E}
-		#endif
-		#if (apiGateway)
 		{815EF0B0-5FDA-4D1E-BACE-DA7E440D5D34} = {8BFE9C37-2620-4156-88B8-286537954C5E}
-		#endif
-		{426A6AB4-95F6-46AC-AB6D-98C4612F74E5} = {35484293-234F-40DA-B430-A95170EDE449}
 		{E5781B96-E0CA-4762-9412-C4202E0CA08F} = {920A23AF-59DA-4453-B825-0549B1C04F5B}
 		{B09E0906-8522-4B70-8C55-958415DAF21D} = {920A23AF-59DA-4453-B825-0549B1C04F5B}
-		#if (filesSupport)
 		{42E51D47-B82F-4A92-B1E5-CD8BE44DE6F0} = {8BFE9C37-2620-4156-88B8-286537954C5E}
-		#endif
+		{1F3073EF-20EF-4BDB-B0DB-065034E76E76} = {35484293-234F-40DA-B430-A95170EDE449}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {42C5F44E-1221-43DF-A6F5-4CB2CBEF8D72}

--- a/src/Monaco.Template.nuspec
+++ b/src/Monaco.Template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Monaco.Template</id>
-		<version>2.0.2</version>
+		<version>2.0.3</version>
 		<title>Monaco Template</title>
 		<description>
 			Templates for .NET projects


### PR DESCRIPTION
## Description
- Refactor FileService to remove remaining dependency on System.Drawing
- Fix BlobStorageService GetFileType() to use string.ToLower()
  - Add unit tests for GetFileType()
- Add unit tests to FileServiceTests
- Remove duplicate Trait declarations in test classes
- General tidy up
- Update packages

## Motivation and Context
#31 replaced System.Drawing implementation, however FileService still had a dependency on System.Drawing for its Size class. As we are not using any specific functionality from the Size class and are just using it to represent data then we can replace it with a tuple.

Other changes in this PR are to:
- fix a bug with the GetFileType method that was not handling strings with uppercase characters properly.
- correct some typos and apply consistent style in some areas
- add unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
