### PR TITLE
FIX: Negation filtering

### DIFF
--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Context/Extensions/FilterExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Context/Extensions/FilterExtensions.cs
@@ -31,7 +31,7 @@ public static class FilterExtensions
 			//generate the expression equivalent to that querystring with the mapping corresponding to the DB
 			var predicateKey = PredicateBuilder.New<T>(false); //Declare a PredicateBuilder for the current key values
 			predicateKey = values.Where(value => ValidateDataType(value, GetBodyExpression(filterMapLower[key]).Type))
-								 .Select(value => GetOperationExpression(key, filterMapLower[key], value)) //then generate the expresion for each value
+								 .Select(value => GetOperationExpression(key, filterMapLower[key], value)) //then generate the expression for each value
 								 .Aggregate(predicateKey, (current, expr) => current.Or(expr)); //and chain them all with an OR operator
 			predicate = allConditions ? predicate.And(predicateKey) : predicate.Or(predicateKey); //then add the resulting expression to the more general predicate
 		}
@@ -153,19 +153,22 @@ public static class FilterExtensions
 		return Expression.Lambda<Func<T, bool>>(expression, fieldMap.Parameters);
 	}
 
-	private static bool ValidateDataType(string? data, Type type) =>
-		data switch
-		{
-			null or { Length: 0 } => true,
-			not null when type == typeof(int) || type == typeof(int?) => int.TryParse(data, out _),
-			not null when type == typeof(long) || type == typeof(long?) => long.TryParse(data, out _),
-			not null when type == typeof(short) || type == typeof(short?) => short.TryParse(data, out _),
-			not null when type == typeof(float) || type == typeof(float?) => float.TryParse(data, out _),
-			not null when type == typeof(decimal) || type == typeof(decimal?) => decimal.TryParse(data, out _),
-			not null when type == typeof(bool) || type == typeof(bool?) => bool.TryParse(data, out _),
-			not null when type == typeof(Guid) || type == typeof(Guid?) => Guid.TryParse(data, out _),
-			not null when type == typeof(DateTime) || type == typeof(DateTime?) => DateTime.TryParse(data, out _),
-			not null when type == typeof(Enum) => Enum.TryParse(type, data, true, out _),
-			_ => type == typeof(string)
-		};
+	private static bool ValidateDataType(string? data, Type type)
+	{
+		data = data is ['!', ..] ? data[1..] : data;
+		return data switch
+			   {
+				   null or { Length: 0 } => true,
+				   not null when type == typeof(int) || type == typeof(int?) => int.TryParse(data, out _),
+				   not null when type == typeof(long) || type == typeof(long?) => long.TryParse(data, out _),
+				   not null when type == typeof(short) || type == typeof(short?) => short.TryParse(data, out _),
+				   not null when type == typeof(float) || type == typeof(float?) => float.TryParse(data, out _),
+				   not null when type == typeof(decimal) || type == typeof(decimal?) => decimal.TryParse(data, out _),
+				   not null when type == typeof(bool) || type == typeof(bool?) => bool.TryParse(data, out _),
+				   not null when type == typeof(Guid) || type == typeof(Guid?) => Guid.TryParse(data, out _),
+				   not null when type == typeof(DateTime) || type == typeof(DateTime?) => DateTime.TryParse(data, out _),
+				   not null when type == typeof(Enum) => Enum.TryParse(type, data, true, out _),
+				   _ => type == typeof(string)
+			   };
+	}
 }

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Monaco.Template.Backend.Common.Infrastructure.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Monaco.Template.Backend.Common.Infrastructure.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-	<PackageVersion>0.0.1-alpha2</PackageVersion>
+	<PackageVersion>0.0.1-alpha1</PackageVersion>
     <Title>Monaco.Template.Backend.Common.Infrastructure</Title>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>One Beyond</Authors>

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Monaco.Template.Backend.Common.Infrastructure.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Monaco.Template.Backend.Common.Infrastructure.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-	<PackageVersion>0.0.1-alpha1</PackageVersion>
+	<PackageVersion>0.0.1-alpha2</PackageVersion>
     <Title>Monaco.Template.Backend.Common.Infrastructure</Title>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>One Beyond</Authors>

--- a/src/Monaco.Template.nuspec
+++ b/src/Monaco.Template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Monaco.Template</id>
-		<version>2.0.3</version>
+		<version>2.0.4</version>
 		<title>Monaco Template</title>
 		<description>
 			Templates for .NET projects


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Description
- Fixes the negation filtering. Example: !0d251643-4026-45f1-a038-cd11e947be19 wasn't passing the validation where it actually should.
- The ValidateDataType method wasn't taking into account that there is an exception where, if the input value comes with a `!` at the beggining should be tried to be validated without it, as it's used for negating when filtering
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Using Monaco template in a project, noticed using the negation while filtering wasn't working as expected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- It's now working as expected

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
