### PR TITLE
FIX: Corrected CORS content-type header

### DIFF
--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Api/appsettings.json
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Api/appsettings.json
@@ -8,8 +8,8 @@
 	"CorsPolicies": [
 		{
 			"Name": "Default",
-			"Origins": [ "http://localhost:3000" ],
-			"Headers": [ "Authorization" ],
+			"Origins": [ "http://localhost:4200" ],
+			"Headers": [ "Authorization", "Content-Type" ],
 			"Methods": [ "GET", "POST", "PUT", "DELETE", "OPTIONS" ]
 		}
 	],

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Queries/CompanyQueriesHandlersTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application.Tests/Features/Company/Queries/CompanyQueriesHandlersTests.cs
@@ -33,7 +33,7 @@ public class CompanyQueriesHandlersTests
 
 		result.Should().NotBeNull();
 		result!.Pager.Count.Should().Be(companies.Count);
-		result.Results
+		result.Items
 			  .Should()
 			  .HaveCount(companies.Count).And
 			  .Contain(x => companies.Any(c => c.Name == x.Name)).And
@@ -58,7 +58,7 @@ public class CompanyQueriesHandlersTests
 
 		result.Should().NotBeNull();
 		result!.Pager.Count.Should().Be(companiesSet.Count);
-		result.Results
+		result.Items
 			  .Should()
 			  .HaveCount(companiesSet.Count).And
 			  .Contain(x => companiesSet.Any(c => c.Name == x.Name)).And

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/PageTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain.Tests/PageTests.cs
@@ -18,7 +18,7 @@ public class PageTests
 		var sut = new Page<string>(results, offset, limit, count);
 
 		sut.Pager.Should().NotBeNull().And.BeEquivalentTo(new Pager(offset, limit, count));
-		sut.Results.Should().OnlyContain(s => results.Contains(s));
+		sut.Items.Should().OnlyContain(s => results.Contains(s));
 	}
 
 	[Trait("Common Domain Entities", "Pager Entity")]

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain/Model/Page.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Domain/Model/Page.cs
@@ -4,13 +4,13 @@ public record Page<T>
 {
 	/// <summary>
 	/// </summary>
-	/// <param name="results">Results subset</param>
+	/// <param name="items">Items subset</param>
 	/// <param name="offset">Record from where to start paging</param>
 	/// <param name="limit">Amount of items to page</param>
 	/// <param name="count">Total amount of items</param>
-	public Page(IEnumerable<T> results, int offset, int limit, long count)
+	public Page(IEnumerable<T> items, int offset, int limit, long count)
 	{
-		Results = results.ToList();
+		Items = items.ToList();
 		Pager = new Pager(offset, limit, count);
 	}
 
@@ -19,9 +19,9 @@ public record Page<T>
 	/// </summary>
 	public Pager Pager { get; }
 	/// <summary>
-	/// Paged results
+	/// Paged items
 	/// </summary>
-	public IReadOnlyList<T> Results { get; }
+	public IReadOnlyList<T> Items { get; }
 }
 
 /// <summary>

--- a/src/Monaco.Template.nuspec
+++ b/src/Monaco.Template.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
 	<metadata>
 		<id>Monaco.Template</id>
-		<version>2.0.4</version>
+		<version>2.1.0</version>
 		<title>Monaco Template</title>
 		<description>
 			Templates for .NET projects


### PR DESCRIPTION
## Description
FIX: Corrected CORS configuration to include Content-Type header by default.
REFACTOR: Rename `Page.Results` to `Page.Items` for better description.

## Related Issue

## Motivation and Context
- When accessing the API from some webapps, it occurs the problem of CORS being rejected because Content-Type is not included by default in the API's CORS configuration. And since it's so easy for this to become a requirement in almost any webapp, then it's better to include it by default.
- The `Page` class contains a list of items being paged called `Results`. This sometimes generates confusion and it's a better description if it would be renamed to `Items` (`Page.Items`)

## How Has This Been Tested?
Unit tests updated accordingly for the Page.Items change.
Manual testing for the CORS configuration.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
