### PR TITLE
FEAT: Dockerization

### DIFF
--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Api/Monaco.Template.Backend.Api.csproj
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Api/Monaco.Template.Backend.Api.csproj
@@ -6,6 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>8ac1d4e3-61ef-452f-a386-ff3ec448fbff</UserSecretsId>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
+    <EnableSdkContainerDebugging>True</EnableSdkContainerDebugging>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,6 +34,15 @@
     <ProjectReference Include="..\Monaco.Template.Backend.Common.Api.Application\Monaco.Template.Backend.Common.Api.Application.csproj" />
     <ProjectReference Include="..\Monaco.Template.Backend.Common.Api\Monaco.Template.Backend.Common.Api.csproj" />
     <ProjectReference Include="..\Monaco.Template.Backend.Common.Serilog\Monaco.Template.Backend.Common.Serilog.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<ContainerEnvironmentVariable Include="ASPNETCORE_HTTP_PORTS">
+      <Value>8080</Value>
+    </ContainerEnvironmentVariable>
+    <ContainerEnvironmentVariable Include="ASPNETCORE_HTTPS_PORTS">
+      <Value>8081</Value>
+    </ContainerEnvironmentVariable>
   </ItemGroup>
 
 </Project>

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Api/Properties/launchSettings.json
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Api/Properties/launchSettings.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "http": {
       "commandName": "Project",
@@ -28,8 +27,30 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "Container (.Net Sdk)": {
+      "commandName": "SdkContainer",
+      "launchBrowser": true,
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "environmentVariables": {
+        "ASPNETCORE_HTTPS_PORTS": "8081",
+        "ASPNETCORE_HTTP_PORTS": "8080"
+      },
+      "publishAllPorts": true,
+      "useSSL": true
+    },
+    "WSL": {
+      "commandName": "WSL2",
+      "launchBrowser": true,
+      "launchUrl": "https://localhost:7070/swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "https://localhost:7070;http://localhost:5050"
+      },
+      "distributionName": ""
     }
   },
+  "$schema": "https://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Api/Properties/launchSettings.json
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Api/Properties/launchSettings.json
@@ -38,16 +38,6 @@
       },
       "publishAllPorts": true,
       "useSSL": true
-    },
-    "WSL": {
-      "commandName": "WSL2",
-      "launchBrowser": true,
-      "launchUrl": "https://localhost:7070/swagger",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_URLS": "https://localhost:7070;http://localhost:5050"
-      },
-      "distributionName": ""
     }
   },
   "$schema": "https://json.schemastore.org/launchsettings.json",

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Api/appsettings.Development.json
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Api/appsettings.Development.json
@@ -1,6 +1,8 @@
 {
 	"ConnectionStrings": {
 		"AppDbContext": "Server=.;Initial Catalog=MonacoTemplate;Integrated Security=true;Encrypt=False;"
+		//If running from Docker the connection string should be changed into something like the following:
+		//"AppDbContext": "Server=host.docker.internal;Initial Catalog=MonacoTemplate;User ID=sa;Password=***;Encrypt=False;Trusted_Connection=false;"
 	},
 
 	"EnableEFSensitiveLogging": true,


### PR DESCRIPTION
## Description
Add the required configurations for dockerizing the project and be able to both publish it into a container image and run it and debug it in a container.

## Related Issue
Closes #26 

## Motivation and Context
As explained in #26, this will help offering support for containers, publish images and debugging capabilities on them out-of-the-box.

## How Has This Been Tested?
API project can now be ran and debugged on a container straight from VS and an image be built straight from the dotnet CLI due to the SDK Container configuration.
A note to consider: current mechanism (SDK Container) is only supported for debugging from VS 2022 v17.9 (currently in Preview).
For publishing the project into an image is enough to run the following command:
```
dotnet publish /p:PublishProfile=DefaultContainer
```
This of course does not depend on VS versions.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
