### PR TITLE
FEAT: Add query caching pipeline behavior

### DIFF
--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/DependencyInjection/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Monaco.Template.Backend.Common.Application.Policies;
 using Monaco.Template.Backend.Common.Infrastructure.Context;
 #if (filesSupport)
 using Monaco.Template.Backend.Common.BlobStorage.Extensions;
+using Monaco.Template.Backend.Common.Application.Queries.Contracts;
 #endif
 
 namespace Monaco.Template.Backend.Application.DependencyInjection;
@@ -54,7 +55,10 @@ public static class ServiceCollectionExtensions
 												opts.ContainerName = optionsValue.BlobStorage.ContainerName;
 											})
 				.AddScoped<IFileService, FileService>();
-		#endif
+#endif
+
+		services.AddMemoryCache();
+		services.AddSingleton<ICachedQueryService, CachedQueryService>();
 
 		return services;
 	}

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Features/Country/GetCountryById.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Features/Country/GetCountryById.cs
@@ -9,7 +9,10 @@ namespace Monaco.Template.Backend.Application.Features.Country;
 
 public sealed class GetCountryById
 {
-	public record Query(Guid Id) : QueryByIdBase<CountryDto?>(Id);
+	public record Query(Guid Id) : CachedQueryByIdBase<CountryDto?>(Id)
+	{
+		public override string CacheKey => $"get-country-by-id-{Id}";
+	}
 
 	public sealed class Handler : IRequestHandler<Query, CountryDto?>
 	{

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Features/Country/GetCountryList.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Features/Country/GetCountryList.cs
@@ -10,7 +10,10 @@ namespace Monaco.Template.Backend.Application.Features.Country;
 
 public sealed class GetCountryList
 {
-	public record Query(IEnumerable<KeyValuePair<string, StringValues>> QueryString) : QueryBase<List<CountryDto>>(QueryString);
+	public record Query(IEnumerable<KeyValuePair<string, StringValues>> QueryString) : CachedQueryBase<List<CountryDto>>(QueryString)
+	{
+		public override string CacheKey => $"get-country-list-{GetQueryStringHashCode()}";
+	}
 
 	public sealed class Handler : IRequestHandler<Query, List<CountryDto>>
 	{

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Services/CachedQueryService.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Services/CachedQueryService.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using Monaco.Template.Backend.Common.Application.Queries.Contracts;
+
+namespace Monaco.Template.Backend.Application.Services;
+
+public class CachedQueryService : ICachedQueryService
+{
+	private static readonly TimeSpan DefaultExpiration = TimeSpan.FromMinutes(5);
+	private readonly IMemoryCache _memoryCache;
+
+	public CachedQueryService(IMemoryCache memoryCache)
+	{
+		_memoryCache = memoryCache;
+	}
+
+	public async Task<T?> GetOrCreateAsync<T>(string cacheKey,
+											  Func<CancellationToken, Task<T>> factory,
+											  TimeSpan? expiration = null,
+											  CancellationToken cancellationToken = default)
+		=> await _memoryCache.GetOrCreateAsync(cacheKey, entry =>
+		{
+			entry.SetAbsoluteExpiration(expiration ?? DefaultExpiration);
+			return factory(cancellationToken);
+		});
+}

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/Behaviors/QueryCachingBehavior.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/Behaviors/QueryCachingBehavior.cs
@@ -1,0 +1,20 @@
+﻿using MediatR;
+using Monaco.Template.Backend.Common.Application.Queries.Contracts;
+
+namespace Monaco.Template.Backend.Common.Application.Queries.Behaviors;
+
+public sealed class QueryCachingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : ICachedQuery
+{
+	private readonly ICachedQueryService _cachedQueryService;
+
+	public QueryCachingBehavior(ICachedQueryService cachedQueryService)
+	{
+		_cachedQueryService = cachedQueryService;
+	}
+
+	public Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+		=> _cachedQueryService.GetOrCreateAsync(request.CacheKey,
+												_ => next(),
+												request.Expiration,
+												cancellationToken)!;
+}

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/CachedQueryBase.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/CachedQueryBase.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Primitives;
+using Monaco.Template.Backend.Common.Application.Queries.Contracts;
+
+namespace Monaco.Template.Backend.Common.Application.Queries;
+
+public abstract record CachedQueryBase<T>(IEnumerable<KeyValuePair<string, StringValues>> QueryString) : QueryBase<T>(QueryString), ICachedQuery<T>
+{
+	public abstract string CacheKey { get; }
+	public virtual TimeSpan? Expiration => null;
+}

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/CachedQueryByIdBase.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/CachedQueryByIdBase.cs
@@ -1,0 +1,9 @@
+﻿using Monaco.Template.Backend.Common.Application.Queries.Contracts;
+
+namespace Monaco.Template.Backend.Common.Application.Queries;
+
+public abstract record CachedQueryByIdBase<T>(Guid Id) : QueryByIdBase<T>(Id), ICachedQuery<T>
+{
+	public abstract string CacheKey { get; }
+	public virtual TimeSpan? Expiration => null;
+}

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/CachedQueryByKeyBase.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/CachedQueryByKeyBase.cs
@@ -1,0 +1,9 @@
+﻿using Monaco.Template.Backend.Common.Application.Queries.Contracts;
+
+namespace Monaco.Template.Backend.Common.Application.Queries;
+
+public abstract record CachedQueryByKeyBase<T, TKey>(TKey Key) : QueryByKeyBase<T, TKey>(Key), ICachedQuery<T>
+{
+	public abstract string CacheKey { get; }
+	public virtual TimeSpan? Expiration => null;
+}

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/CachedQueryPagedBase.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/CachedQueryPagedBase.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Primitives;
+using Monaco.Template.Backend.Common.Application.Queries.Contracts;
+
+namespace Monaco.Template.Backend.Common.Application.Queries;
+
+public abstract record CachedQueryPagedBase<T>(IEnumerable<KeyValuePair<string, StringValues>> QueryString) : QueryPagedBase<T>(QueryString), ICachedQuery<T>
+{
+	public abstract string CacheKey { get; }
+	public virtual TimeSpan? Expiration => null;
+}

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/Contracts/ICachedQuery.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/Contracts/ICachedQuery.cs
@@ -1,0 +1,11 @@
+﻿using MediatR;
+
+namespace Monaco.Template.Backend.Common.Application.Queries.Contracts;
+
+public interface ICachedQuery
+{
+	public abstract string CacheKey { get; }
+	public TimeSpan? Expiration { get; }
+}
+
+public interface ICachedQuery<T> : IRequest<T>, ICachedQuery;

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/Contracts/ICachedQueryService.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/Contracts/ICachedQueryService.cs
@@ -1,0 +1,9 @@
+﻿namespace Monaco.Template.Backend.Common.Application.Queries.Contracts;
+
+public interface ICachedQueryService
+{
+	Task<T?> GetOrCreateAsync<T>(string key,
+								 Func<CancellationToken, Task<T>> factory,
+								 TimeSpan? expiration = null,
+								 CancellationToken cancellationToken = default);
+}

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/QueryBase.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Application/Queries/QueryBase.cs
@@ -59,4 +59,15 @@ public abstract record QueryBase<T>(IEnumerable<KeyValuePair<string, StringValue
 																						.Value
 																						.Select(x => Enum.TryParse<TEnum>(x, true, out var y) ? y : (TEnum?)null)
 																						.FirstOrDefault(x => x is not null);
+
+	public int GetQueryStringHashCode()
+	{
+		int hash = 17;
+		foreach (var (key, value) in QueryString)
+		{
+			hash = (hash * 23) + key.GetHashCode();
+			hash = (hash * 23) + value.GetHashCode();
+		}
+		return hash;
+	}
 }


### PR DESCRIPTION
## Description
Implement a query caching pipeline behavior. 
Adds cached versions of each of the existing query base classes:
`CachedQueryBase`
`CachedQueryPagedBase`
`CachedQueryByIdBase`
`CachedQueryByKeyBase`

Any query definition inheriting from a cached query base class is required to override the `CacheKey` property. This should be defined in a way that results in a cache key that is specific to the parameters of that query. Where the query includes a `QueryString` the base class `QueryBase` has been updated to include a method `GetQueryStringHashCode` to help with generating an appropriate cache key.

## Related Issue
#8 

## Motivation and Context
Allows specific queries to have their result cached for a given time period (defaults of 5 minutes but can be set on each query definition as needed) meaning that subsequent calls to that query endpoint matching the cache key will return the cached result without requiring a roundtrip to the database.

## How Has This Been Tested?
Tested queries inheriting from the base classes `CachedQueryByIdBase`, `CachedQueryBase`, `CachedQueryPagedBase` with SQL server profiler to confirm that only the first query within the specified cache expiration window resulted in a database query to retrieve the query results, subsequent queries matching the cache key returned the results without any database query.

Additionally, tested changing query parameters to the same endpoint within the cache expiration window resulted in a different cache key and a database query to fetch new data. Any subsequent calls to the endpoint using previously used query params within the cache expiration window would return the cached results.

Once the cache expiration window had expired the next call to the endpoint successfully queried the database and cached the results.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
