### PR TITLE
FIX: filtering on Enum properties

### DIFF
--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Context/Extensions/FilterExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Common.Infrastructure/Context/Extensions/FilterExtensions.cs
@@ -128,7 +128,7 @@ public static class FilterExtensions
 			}
 		}
 		else if (type.IsEnum)
-			expression = Expression.Equal(bodyExpression, Expression.Constant(Enum.Parse(type, (string.IsNullOrWhiteSpace(value?.ToString()) ? 0.ToString() : value!.ToString()) ?? 0.ToString())));
+			expression = Expression.Equal(bodyExpression, Expression.Constant(Enum.Parse(type, (string.IsNullOrWhiteSpace(value?.ToString()) ? "0" : value!.ToString()) ?? "0")));
 		else if (type.IsAssignableFrom(typeof(Guid))) // Handles Guid values
 			expression = value.ToString() is ['!', ..]
 							 ? Expression.NotEqual(bodyExpression, Expression.Constant(Guid.Parse(value.ToString()![1..]), type))


### PR DESCRIPTION
## Description
Changes the type check within the switch expression to properly capture Enum types.

## Motivation and Context
Fixes an issue with filtering on Enum types as the type check in the switch expression within the method `ValidateDataType` was not capturing Enum types.

## How Has This Been Tested?
Tested in other projects using Monaco as a base.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
