### PR TITLE
CHORE: use domain string property length constants

### DIFF
--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Features/Company/CreateCompany.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Features/Company/CreateCompany.cs
@@ -27,29 +27,29 @@ public sealed class CreateCompany
 
 			RuleFor(x => x.Name)
 				.NotEmpty()
-				.MaximumLength(100)
+				.MaximumLength(Domain.Model.Entities.Company.NameLength)
 				.MustAsync(async (name, ct) => !await dbContext.ExistsAsync<Domain.Model.Entities.Company>(x => x.Name == name, ct))
 				.WithMessage("A company with the name {PropertyValue} already exists");
 
 			RuleFor(x => x.Email)
 				.NotEmpty()
 				.EmailAddress()
-				.MaximumLength(255);
+				.MaximumLength(Domain.Model.Entities.Company.EmailLength);
 
 			RuleFor(x => x.WebSiteUrl)
-				.MaximumLength(300);
+				.MaximumLength(Domain.Model.Entities.Company.WebSiteUrlLength);
 
 			RuleFor(x => x.Street)
-				.MaximumLength(100);
+				.MaximumLength(Domain.Model.ValueObjects.Address.StreetLength);
 
 			RuleFor(x => x.City)
-				.MaximumLength(100);
+				.MaximumLength(Domain.Model.ValueObjects.Address.CityLength);
 
 			RuleFor(x => x.County)
-				.MaximumLength(100);
+				.MaximumLength(Domain.Model.ValueObjects.Address.CountyLength);
 
 			RuleFor(x => x.PostCode)
-				.MaximumLength(10);
+				.MaximumLength(Domain.Model.ValueObjects.Address.PostCodeLength);
 
 			RuleFor(x => x.CountryId)
 				.NotNull()

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Features/Company/EditCompany.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Features/Company/EditCompany.cs
@@ -31,31 +31,30 @@ public sealed class EditCompany
 
 			RuleFor(x => x.Name)
 				.NotEmpty()
-				.MaximumLength(100)
+				.MaximumLength(Domain.Model.Entities.Company.NameLength)
 				.MustAsync(async (cmd, name, ct) => !await dbContext.ExistsAsync<Domain.Model.Entities.Company>(x => x.Id != cmd.Id &&
-																											x.Name == name,
-																									   ct))
+																											         x.Name == name, ct))
 				.WithMessage("Another company with the name {PropertyValue} already exists");
 
 			RuleFor(x => x.Email)
 				.NotEmpty()
 				.EmailAddress()
-				.MaximumLength(255);
+				.MaximumLength(Domain.Model.Entities.Company.EmailLength);
 
 			RuleFor(x => x.WebSiteUrl)
-				.MaximumLength(300);
+				.MaximumLength(Domain.Model.Entities.Company.WebSiteUrlLength);
 
 			RuleFor(x => x.Street)
-				.MaximumLength(100);
+				.MaximumLength(Domain.Model.ValueObjects.Address.StreetLength);
 
 			RuleFor(x => x.City)
-				.MaximumLength(100);
+				.MaximumLength(Domain.Model.ValueObjects.Address.CityLength);
 
 			RuleFor(x => x.County)
-				.MaximumLength(100);
+				.MaximumLength(Domain.Model.ValueObjects.Address.CountyLength);
 
 			RuleFor(x => x.PostCode)
-				.MaximumLength(10);
+				.MaximumLength(Domain.Model.ValueObjects.Address.PostCodeLength);
 
 			RuleFor(x => x.CountryId)
 				.NotNull()

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Features/Product/CreateProduct.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Application/Features/Product/CreateProduct.cs
@@ -9,8 +9,6 @@ using Monaco.Template.Backend.Common.Application.Commands;
 using Monaco.Template.Backend.Common.Application.Validators.Extensions;
 using Monaco.Template.Backend.Common.Infrastructure.Context.Extensions;
 using Monaco.Template.Backend.Domain.Model.Entities;
-#if (massTransitIntegration)
-#endif
 
 namespace Monaco.Template.Backend.Application.Features.Product;
 
@@ -98,7 +96,7 @@ public sealed class CreateProduct
 
 			await _publishEndpoint.Publish(item.MapMessage(), cancellationToken);
 #endif
-			
+
 			await _dbContext.SaveEntitiesAsync(cancellationToken);
 
 			return CommandResult<Guid>.Success(item.Id);

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.ArchitectureTests/Extensions/ArchUnitExtensions.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.ArchitectureTests/Extensions/ArchUnitExtensions.cs
@@ -1,6 +1,4 @@
-﻿using ArchUnitNET.Domain;
-using ArchUnitNET.Domain.Extensions;
-using ArchUnitNET.Fluent.Syntax.Elements.Types.Classes;
+﻿using ArchUnitNET.Fluent.Syntax.Elements.Types.Classes;
 
 namespace Monaco.Template.Backend.ArchitectureTests.Extensions;
 

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/AddressTests.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/AddressTests.cs
@@ -20,7 +20,7 @@ public class AddressTests
 								   string? postCode,
 								   Country country)
 	{
-		postCode = postCode?[..10];
+		postCode = postCode?[..Address.PostCodeLength];
 		var sut = new Address(street,
 							  city,
 							  county,

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/Factories/Entities/AddressFactory.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/Factories/Entities/AddressFactory.cs
@@ -1,6 +1,5 @@
 ﻿using AutoFixture;
 using Monaco.Template.Backend.Common.Tests;
-using Monaco.Template.Backend.Domain.Model;
 using Monaco.Template.Backend.Domain.Model.Entities;
 using Monaco.Template.Backend.Domain.Model.ValueObjects;
 using Moq;
@@ -27,7 +26,7 @@ public static class AddressFactoryExtensions
 		fixture.Register(() => new Address(fixture.Create<string?>(),
 										   fixture.Create<string?>(),
 										   fixture.Create<string?>(),
-										   fixture.Create<string?>()?[..10],
+										   fixture.Create<string?>()?[..Address.PostCodeLength],
 										   fixture.Create<Country>()));
 		return fixture;
 	}
@@ -40,7 +39,7 @@ public static class AddressFactoryExtensions
 							 var mock = new Mock<Address>(fixture.Create<string?>()!,
 														  fixture.Create<string?>()!,
 														  fixture.Create<string?>()!,
-														  fixture.Create<string?>()?[..10]!,
+														  fixture.Create<string?>()?[..Address.PostCodeLength]!,
 														  country);
 							 return mock.Object;
 						 });

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/Factories/Entities/CompanyFactory.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/Factories/Entities/CompanyFactory.cs
@@ -1,6 +1,5 @@
 ﻿using AutoFixture;
 using Monaco.Template.Backend.Common.Tests;
-using Monaco.Template.Backend.Domain.Model;
 using Monaco.Template.Backend.Domain.Model.Entities;
 using Monaco.Template.Backend.Domain.Model.ValueObjects;
 using Moq;
@@ -22,7 +21,7 @@ public static class CompanyFactory
 	public static Mock<Company> Mock()
 	{
 		var fixture = FixtureFactory.Create(f => f.RegisterAddress());
-		
+
 		var mock = new Mock<Company>(fixture.Create<string>(),
 									 fixture.Create<string>(),
 									 fixture.Create<string>(),

--- a/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/Factories/Entities/DocumentFactory.cs
+++ b/src/Content/Backend/Solution/Monaco.Template.Backend.Domain.Tests/Factories/Entities/DocumentFactory.cs
@@ -21,7 +21,7 @@ public static class DocumentFactoryExtension
 	{
 		fixture.Register(() => new Document(fixture.Create<Guid>(),
 											fixture.Create<string>(),
-											fixture.Create<string>()[..20],
+											fixture.Create<string>()[..Document.ExtensionLength],
 											fixture.Create<long>(),
 											fixture.Create<string>(),
 											false));


### PR DESCRIPTION
## Description
- Use the existing domain string property length constants in validators and test factories where missing
- Remove an empty/unused pre-processor directive

## How Has This Been Tested?
Unit tests pass as expected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
